### PR TITLE
Add birth_date and update date_no_time prompttypes

### DIFF
--- a/odkx-src/xlsx-converter-reference.rst
+++ b/odkx-src/xlsx-converter-reference.rst
@@ -316,10 +316,12 @@ The following prompt types are available in ODK-X Survey.
     - | Used to capture an audio recording.
   * - barcode
     - | Used to capture a barcode.
-  * - date_no_time
-    - | Uses a date picker widget to capture a date.
+  * - date
+    - | Uses a date picker widget to capture a date. Accounts for the local time zone.
   * - datetime
     - | Uses a date time picker widget to capture a date and time.
+  * - date_no_time
+    - | Uses a date picker widget to capture a date. Ignores the local time zone and just stores the selected date. 
   * - birth_date
     - | Uses a date picker widget to capture a birth date. Currently behaves the same as `date_no_time`. 
   * - decimal

--- a/odkx-src/xlsx-converter-reference.rst
+++ b/odkx-src/xlsx-converter-reference.rst
@@ -316,10 +316,12 @@ The following prompt types are available in ODK-X Survey.
     - | Used to capture an audio recording.
   * - barcode
     - | Used to capture a barcode.
-  * - date
+  * - date_no_time
     - | Uses a date picker widget to capture a date.
   * - datetime
     - | Uses a date time picker widget to capture a date and time.
+  * - birth_date
+    - | Uses a date picker widget to capture a birth date. Currently behaves the same as `date_no_time`. 
   * - decimal
     - | Used to display a message to the user and have them enter a decimal.
   * - geopoint

--- a/odkx-src/xlsx-converter-reference.rst
+++ b/odkx-src/xlsx-converter-reference.rst
@@ -317,11 +317,11 @@ The following prompt types are available in ODK-X Survey.
   * - barcode
     - | Used to capture a barcode.
   * - date
-    - | Uses a date picker widget to capture a date. Accounts for the local time zone.
+    - | Uses a date picker widget to capture a date. Automatically adjusts for timezone.
   * - datetime
-    - | Uses a date time picker widget to capture a date and time.
+    - | Uses a date time picker widget to capture a date and time. Automatically adjusts for timezone.
   * - date_no_time
-    - | Uses a date picker widget to capture a date. Ignores the local time zone and just stores the selected date. 
+    - | Uses a date picker widget to capture a date. Does not adjust for timezone.
   * - birth_date
     - | Uses a date picker widget to capture a birth date. Currently behaves the same as `date_no_time`. 
   * - decimal


### PR DESCRIPTION
Should be merged with release 2.1.7

#### What is included in this PR?
This PR brings the date prompt types section of the docs up to date with with the latest changes in 2.1.7. 
