### PR TITLE
Pin ruby to version 2.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
   deploy-odkx:
     working_directory: ~/work
     docker:
-      - image: circleci/ruby:latest
+      - image: circleci/ruby:2.7.2
     steps:
       - attach_workspace:
           at: ~/work


### PR DESCRIPTION
#### What is included in this PR?
Pin CircleCI's Ruby to version 2.7.2 to fix `s3_website`. `s3_website` is incompatible with Ruby version 3. A similar change was merged earlier to [odk-x/website](https://github.com/odk-x/website). See odk-x/website#26