### PR TITLE
Fix validation tags docs

### DIFF
--- a/odkx-src/xlsx-converter-reference.rst
+++ b/odkx-src/xlsx-converter-reference.rst
@@ -294,6 +294,12 @@ A list of the optional columns that can be incorporated into a **survey** worksh
     - | Must be used with the **choices** worksheet. The :th:`value_list`
       | column of the **survey** worksheet connects to the
       | :th:`choice_list_name` column on the **choices** worksheet.
+  * - validation_tags
+    - | Space-separated list of validation tags.
+      | If validation tags are present on any prompt, this column does not
+      | have a default value.
+      | If this column is absent, left blank, or otherwise empty, its default value
+      | is :tc:`finalize`.
 
 .. _xlsx-ref-survey-prompt-types:
 
@@ -1051,5 +1057,3 @@ The built-in formula functions can be combined in advanced ways using any valid 
 .. Tip::
 
   Make sure that statements using :code:`&&` and :code:`||` operators for variables that were :th:`select_one` type are logical and that they work as intended. For example, if the variable :code:`pizza_type` had been a :th:`select_one`, the statement :code:`(selected(data('pizza_type'), 'mushroom') && selected(data('pizza_type'), 'onions')` could never be valid, because the respondent could only have selected one or the other or neither, not both. Therefore, the example instead uses a :code:`||` statement.
-
-

--- a/odkx-src/xlsx-converter-using.rst
+++ b/odkx-src/xlsx-converter-using.rst
@@ -467,8 +467,8 @@ The **section1** worksheet would look like this:
 .. csv-table:: Validate Section1 Worksheet Example
   :header: "type", "name", "display.prompt.text", "required", "validation_tags"
 
-  "text", "user_name", "What is your name?", "TRUE", "user_info, finalize"
-  "integer", "user_age", "What is your age?", "TRUE", "user_info, finalize"
+  "text", "user_name", "What is your name?", "TRUE", "user_info finalize"
+  "integer", "user_age", "What is your age?", "TRUE", "user_info finalize"
   "note",, "Thank you for answering",
 
 The **section2** worksheet would look like this:
@@ -476,7 +476,7 @@ The **section2** worksheet would look like this:
 .. csv-table:: Validate Section2 Worksheet Example
   :header: "type", "name", "display.prompt.text", "required", "validation_tags"
 
-  "text", "occupation", "What is your current occupation?", "TRUE", "user_info, finalize"
+  "text", "occupation", "What is your current occupation?", "TRUE", "user_info finalize"
   "integer", "user_age", "How long have you worked at your current job (in years)?", "TRUE", "finalize"
   "note",, "Thank you for answering",
 


### PR DESCRIPTION
#### What is included in this PR?
This PR fixes validation tags examples. 
The tags should be defined in a space-separated list as specified in the [formDef.json documentation](https://docs.odk-x.org/formdef-structure/#sections-sub-component) and [implemented in XLSXConverter2](https://github.com/odk-x/app-designer/blob/7abf14b16d940850cedfa66e2f9c2afd79553b3e/xlsxconverter/XLSXConverter2.js#L1300-L1302).