### PR TITLE
Add examples for CLI options

### DIFF
--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -119,7 +119,7 @@ Combine the individual commands described in the help to perform the actions nee
 
     .. code-block:: console
 
-      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -update -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -username "user" -password "pass" -dataVersion "Version" -tableId "table_id" -path "/home/user/Desktop/example.csv" -updateLogPath "/home/user/Desktop/log.txt"
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -update -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -username "user" -password "pass" -path "/home/user/Desktop/example.csv" -updateLogPath "/home/user/Desktop/log.txt"
 
 To script the CLI, write the commands you would like to execute in a scripting language (for example, Bash, Batch, Python, Ruby) and use a scheduler (such as Cron or Windows Task Scheduler) to schedule the tasks. To skip over ODK-X Suitcase's prompts to overwrite, pass :code:`-f` as an argument to ODK-X Suitcase.
 

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -125,12 +125,12 @@ Combine the individual commands described in the help to perform the actions nee
 
     .. code-block:: console
 
-      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp RESET_APP -username "user" -password "pass" -path "/home/user/Desktop/example.csv"      
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp "RESET_APP" -username "user" -password "pass" -path "/home/user/Desktop/example.csv"      
   - To upload CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* with username *user* and password *pass* and uploadOp as RESET_APP:
 
     .. code-block:: console
 
-      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp RESET_APP -username "user" -password "pass" -path "/home/user/Desktop/example.csv"
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp "RESET_APP" -username "user" -password "pass" -path "/home/user/Desktop/example.csv"
 
 
 To script the CLI, write the commands you would like to execute in a scripting language (for example, Bash, Batch, Python, Ruby) and use a scheduler (such as Cron or Windows Task Scheduler) to schedule the tasks. To skip over ODK-X Suitcase's prompts to overwrite, pass :code:`-f` as an argument to ODK-X Suitcase.

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -109,11 +109,17 @@ Combine the individual commands described in the help to perform the actions nee
 
       $ java -jar suitcase.jar -download -a -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -tableId "table_id" -username "user" -password "pass" -path "~/Desktop"
       
-  - To update CSV at location `/home/user/Desktop/example.csv` of table *table_id* from app *default* as an anonymous user and store the log at "/home/user/Desktop/log.txt":
+  - To update CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* as an anonymous user and store the log at "/home/user/Desktop/log.txt":
 
     .. code-block:: console
 
       $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -update -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -path "/home/user/Desktop/example.csv" -updateLogPath "/home/user/Desktop/log.txt"
+      
+  - To update CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* with username *user* and password *pass* and store the log at "/home/user/Desktop/log.txt":
+
+    .. code-block:: console
+
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -update -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -username "user" -password "pass" -dataVersion "Version" -tableId "table_id" -path "/home/user/Desktop/example.csv" -updateLogPath "/home/user/Desktop/log.txt"
 
 To script the CLI, write the commands you would like to execute in a scripting language (for example, Bash, Batch, Python, Ruby) and use a scheduler (such as Cron or Windows Task Scheduler) to schedule the tasks. To skip over ODK-X Suitcase's prompts to overwrite, pass :code:`-f` as an argument to ODK-X Suitcase.
 

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -126,6 +126,7 @@ Combine the individual commands described in the help to perform the actions nee
     .. code-block:: console
 
       $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp "RESET_APP" -username "user" -password "pass" -path "/home/user/Desktop/example.csv"      
+
   - To upload CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* with username *user* and password *pass* and uploadOp as RESET_APP:
 
     .. code-block:: console

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -121,16 +121,16 @@ Combine the individual commands described in the help to perform the actions nee
 
       $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -update -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -username "user" -password "pass" -path "/home/user/Desktop/example.csv" -updateLogPath "/home/user/Desktop/log.txt"
       
-  - To upload CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* as an anonymous user and uploadOp as FILE:
+  - To upload CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* as an anonymous user and uploadOp as RESET_APP:
 
     .. code-block:: console
 
-      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp FILE -username "user" -password "pass" -path "/home/user/Desktop/example.csv"      
-  - To upload CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* with username *user* and password *pass* and uploadOp as FILE:
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp RESET_APP -username "user" -password "pass" -path "/home/user/Desktop/example.csv"      
+  - To upload CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* with username *user* and password *pass* and uploadOp as RESET_APP:
 
     .. code-block:: console
 
-      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp FILE -username "user" -password "pass" -path "/home/user/Desktop/example.csv"
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp RESET_APP -username "user" -password "pass" -path "/home/user/Desktop/example.csv"
 
 
 To script the CLI, write the commands you would like to execute in a scripting language (for example, Bash, Batch, Python, Ruby) and use a scheduler (such as Cron or Windows Task Scheduler) to schedule the tasks. To skip over ODK-X Suitcase's prompts to overwrite, pass :code:`-f` as an argument to ODK-X Suitcase.

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -120,6 +120,18 @@ Combine the individual commands described in the help to perform the actions nee
     .. code-block:: console
 
       $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -update -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -username "user" -password "pass" -path "/home/user/Desktop/example.csv" -updateLogPath "/home/user/Desktop/log.txt"
+      
+  - To upload CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* as an anonymous user and uploadOp as FILE:
+
+    .. code-block:: console
+
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp FILE -username "user" -password "pass" -path "/home/user/Desktop/example.csv"      
+  - To upload CSV at location "/home/user/Desktop/example.csv" of table *table_id* from app *default* with username *user* and password *pass* and uploadOp as FILE:
+
+    .. code-block:: console
+
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp FILE -username "user" -password "pass" -path "/home/user/Desktop/example.csv"
+
 
 To script the CLI, write the commands you would like to execute in a scripting language (for example, Bash, Batch, Python, Ruby) and use a scheduler (such as Cron or Windows Task Scheduler) to schedule the tasks. To skip over ODK-X Suitcase's prompts to overwrite, pass :code:`-f` as an argument to ODK-X Suitcase.
 

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -132,6 +132,13 @@ Combine the individual commands described in the help to perform the actions nee
     .. code-block:: console
 
       $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -uploadOp "RESET_APP" -username "user" -password "pass" -path "/home/user/Desktop/example.csv"
+      
+ 
+  - To reset the server:
+
+    .. code-block:: console
+
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" 
 
 
 To script the CLI, write the commands you would like to execute in a scripting language (for example, Bash, Batch, Python, Ruby) and use a scheduler (such as Cron or Windows Task Scheduler) to schedule the tasks. To skip over ODK-X Suitcase's prompts to overwrite, pass :code:`-f` as an argument to ODK-X Suitcase.

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -108,6 +108,12 @@ Combine the individual commands described in the help to perform the actions nee
     .. code-block:: console
 
       $ java -jar suitcase.jar -download -a -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -tableId "table_id" -username "user" -password "pass" -path "~/Desktop"
+      
+  - To update CSV at location `/home/user/Desktop/example.csv` of table *table_id* from app *default* as an anonymous user and store the log at "/home/user/Desktop/log.txt":
+
+    .. code-block:: console
+
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -update -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" -tableId "table_id" -path "/home/user/Desktop/example.csv" -updateLogPath "/home/user/Desktop/log.txt"
 
 To script the CLI, write the commands you would like to execute in a scripting language (for example, Bash, Batch, Python, Ruby) and use a scheduler (such as Cron or Windows Task Scheduler) to schedule the tasks. To skip over ODK-X Suitcase's prompts to overwrite, pass :code:`-f` as an argument to ODK-X Suitcase.
 

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -138,7 +138,7 @@ Combine the individual commands described in the help to perform the actions nee
 
     .. code-block:: console
 
-      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -upload -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" 
+      $ java -jar "ODK Suitcase v2.0.3 rev 220.jar" -reset -cloudEndpointUrl "https://your-endpoint-server.com" -appId "default" -dataVersion "Version" 
 
 
 To script the CLI, write the commands you would like to execute in a scripting language (for example, Bash, Batch, Python, Ruby) and use a scheduler (such as Cron or Windows Task Scheduler) to schedule the tasks. To skip over ODK-X Suitcase's prompts to overwrite, pass :code:`-f` as an argument to ODK-X Suitcase.


### PR DESCRIPTION
CLI documentation didn't include update , reset  and upload options.
Examples of CLI commands for Update and Upload are included .




