### PR TITLE
Add documentaion for advanced configuration of LDAP

### DIFF
--- a/odkx-src/sync-endpoint-manual-setup.rst
+++ b/odkx-src/sync-endpoint-manual-setup.rst
@@ -151,14 +151,43 @@ Custom LDAP directory
 
       $ docker config create org.opendatakit.sync.ldapcert PATH_TO_CERT
 
-    b. Uncomment the relevant lines in the *configs* section in :file:`docker-compose.yml` and the *configs* section under the *sync* section in :file:`docker-compose.yml`.
+    b. Uncomment the relevant lines in the *configs* section in :file:`docker-compose.yml` and the *configs* section under the *sync* section in :file:`docker-
+       compose.yml`.
+       
+  3. Create a new directory in the sync-endpoint-default-setup directory and create a Docker file inside it.
+  4. Copy the bootstrap.ldif file from the OpenLDAP directory to the new directory. In the Docker file Add the image of the LDAP Directory to be used and add 
+     the "COPY" command to copy the bootstrap.ldif file to the right path in the container.
+  5. Run the following command to build the Docker image :
+    
+    .. code-block:: console
 
-  3. Remove the *ldap-service* and *phpldapadmin* sections in :file:`docker-compose.yml`.
-  4. Modify the relevant sections in :file:`security.properties` to match your LDAP directory. Further instructions are in the file.
+      $ docker build -t odk/[LDAP_DIRECTORY_NAME] [ Folder conatining the Docker file ]
 
-  .. note::
+  6. Replace the ldap-service image from docker-compose.yml with odk/[LDAP_DIRECTORY_NAME].
+  7. In the sync-endpoint-default-setup directory navigate to config/sync-endpoint. Modify the :file:`security.properties` file to fill in the Settings for LDAP 
+     server. Set security.server.ldapUrl in security.properties to the new server url. The name of the service in Swarm would be same ( ldap-service ). So just 
+     change the port number. After this following settings need to be configured in the same file for the LDAP server:
 
-    The default configuration does not use ldaps or StartTLS because the LDAP directory communicates with the ODK-X Sync Endpoint over a secure overlay network. You should use ldaps or StartTLS to communicate with your LDAP directory.
+       - :guilabel:`security.server.ldapBaseDn`
+       - :guilabel:`security.server.ldapPooled`
+       - :guilabel:`security.server.userSearchBase`
+       - :guilabel:`security.server.groupSearchBase`
+       - :guilabel:`security.server.groupRoleAttribute`
+       - :guilabel:`security.server.userFullnameAttribute`
+       - :guilabel:`security.server.usernameAttribute`
+       - :guilabel:`security.server.userDnPattern`
+       - :guilabel:`security.server.memberOfGroupSearchFilter`
+       - :guilabel:`security.server.serverGroupSearchFilter`
+
+    .. note::
+
+      The LDAP Directory here is configured to run inside the Docker Swarm. If you are running the LDAP Directory outside the Docker Swarm and it is accessible 
+      for the containers inside the Docker Swarm, you can directly follow step 7 to configure it.
+
+    .. note::
+
+      The default configuration does not use ldaps or StartTLS because the LDAP directory communicates with the ODK-X Sync Endpoint over a secure overlay network. 
+      You should use ldaps or StartTLS to communicate with your LDAP directory.
 
   5. In the cloned repository:
 

--- a/odkx-src/sync-endpoint-manual-setup.rst
+++ b/odkx-src/sync-endpoint-manual-setup.rst
@@ -153,8 +153,7 @@ Custom LDAP directory
 
       $ docker config create org.opendatakit.sync.ldapcert PATH_TO_CERT
 
-    b. Uncomment the relevant lines in the *configs* section in :file:`docker-compose.yml` and the *configs* section under the *sync* section in :file:`docker-
-       compose.yml`.
+    b. Uncomment the relevant lines in the *configs* section in :file:`docker-compose.yml` and the *configs* section under the *sync* section in :file:`docker-compose.yml`.
        
   3. Create a new directory in the sync-endpoint-default-setup directory and create a Docker file inside it.
   4. Copy the :file:`bootstrap.ldif` file from the OpenLDAP directory to the new directory. In the Docker file Add the image of the LDAP Directory to be used 

--- a/odkx-src/sync-endpoint-manual-setup.rst
+++ b/odkx-src/sync-endpoint-manual-setup.rst
@@ -1,6 +1,8 @@
 .. spelling::
   phpLDAPadmin
   readonly
+  ldapUrl
+  ldap
 
 .. _sync-endpoint-manual-setup:
 
@@ -155,15 +157,15 @@ Custom LDAP directory
        compose.yml`.
        
   3. Create a new directory in the sync-endpoint-default-setup directory and create a Docker file inside it.
-  4. Copy the bootstrap.ldif file from the OpenLDAP directory to the new directory. In the Docker file Add the image of the LDAP Directory to be used and add 
-     the "COPY" command to copy the bootstrap.ldif file to the right path in the container.
+  4. Copy the :file:`bootstrap.ldif` file from the OpenLDAP directory to the new directory. In the Docker file Add the image of the LDAP Directory to be used 
+     and add the "COPY" command to copy the :file:`bootstrap.ldif` file to the right path in the container.
   5. Run the following command to build the Docker image :
     
     .. code-block:: console
 
       $ docker build -t odk/[LDAP_DIRECTORY_NAME] [ Folder conatining the Docker file ]
 
-  6. Replace the ldap-service image from docker-compose.yml with odk/[LDAP_DIRECTORY_NAME].
+  6. Replace the ldap-service image from :file:`docker-compose.yml` with odk/[LDAP_DIRECTORY_NAME].
   7. In the sync-endpoint-default-setup directory navigate to config/sync-endpoint. Modify the :file:`security.properties` file to fill in the Settings for LDAP 
      server. Set security.server.ldapUrl in security.properties to the new server url. The name of the service in Swarm would be same ( ldap-service ). So just 
      change the port number. After this following settings need to be configured in the same file for the LDAP server:

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -168,7 +168,9 @@ Editing the defaults of LDAP directory
        LDAP_ADMIN_PASSWORD=admin                  // default password for admin account 
 
        # phpldapadmin
-       PHPLDAPADMIN_LDAP_HOSTS=ldap-service   // ldap-service is the host of OpenLDAP . This is for the phpLDAPadmin
+       PHPLDAPADMIN_LDAP_HOSTS=ldap-service   // This is for the phpLDAPadmin . In docker swarm this is the name of the service running LDAP . This can be eddited
+                                                 in the docker-compose.yml file
+                                                 
    
 .. _sync-endpoint-custom-ldap:
 

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -264,7 +264,7 @@ Warnings
 --------
  - The database and the LDAP directory set up here are meant only for testing and evaluation. When running in production you should configure a production ready 
    database and a production ready LDAP directory. Using the pre-configured database and directory in production can result in poor performance and degraded 
-   availabilitiy.
+   availability.
  - You should refer to Docker Swarm documentation on running a production ready Swarm.
  - We recommend that you host Sync Endpoint on a commercial cloud provider (e.g. Google Cloud Platform, Amazon AWS, Microsoft Azure, etc.) If you want to host 
    Sync Endpoint on premise, you should consult your System Administrator for appropriate hardware.

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -202,7 +202,8 @@ Using a Different LDAP UI
 """"""""""""""""""""""""""""""""""""""""""""""
     
     If you want to use a UI outside the docker swarm in your local machine Modify the docker-compose.yml file in sync-endpoint-default-setup directory . Add ports 
-    mapping to the ldap service to expose the port 389 of ldap service to a port in your local host . Connect the UI application to this port on localhost.
+    mapping to the ldap service to expose the port 389 of ldap service to a port in your local host . If you wish to access 
+    the ldap protocol over TLS/SSL expose the port 636. Connect the UI application to this port on localhost.
     
     The ldap service of the the docker compose should be like this after adding port mapping .
     

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -4,6 +4,15 @@
   letsencrypt
   OpenLDAP
   ldif
+  utils
+  ldap
+  env
+  yml
+  ldapUrl
+  localhost
+  UI
+  authenticationMethod
+  dhis
 
 ODK-X Sync Endpoint
 ===================
@@ -70,7 +79,7 @@ If you'd prefer to use the :program:`OpenLDAP` command line utilities, they're i
   - Linux/macOS:
 
   .. code-block:: console
-
+ 
     $ docker exec $(docker ps -f "label=com.docker.swarm.service.name=syncldap_ldap-service" --format '{{.ID}}') LDAPTOOL ARGS
 
   - Windows:
@@ -140,14 +149,14 @@ Assigning users to groups
 Using LDAP utils
 """""""""""""""""""""""""
 
-  The ldap-service container has ldap-utils installed. If you'd prefer, you may use that toolset to administer the LDAP directory as well. Use this command to
+  The ldap-service container has ldap-utils installed. If you'd prefer, you may use that tool set to administer the LDAP directory as well. Use this command to
   access them,
  
     .. code-block:: console
   
      $ docker exec $(docker ps -f "label=com.docker.swarm.service.name=${STACK_NAME}_sync" --format '{{.ID}}') <LDAPTOOL> <ARGS>
      
-    The docker exec takes a container name and a command . The command is executed in the sepcified container . 
+    The docker exec takes a container name and a command . The command is executed in the specified container . 
     
 .. _sync-endpoint-advanced:
 
@@ -234,7 +243,7 @@ Using a Different LDAP UI
   
        $ docker build -t odk/[YOUR_UI_APPLICATION_NAME] [ Folder conatining the docker file ]
        
-    Edit the docke-compose.yml file . Replace the image of phpldapadmin service with odk/[YOUR_UI_APPLICATION_NAME] . 
+    Edit the docker-compose.yml file . Replace the image of phpLDAPadmin service with odk/[YOUR_UI_APPLICATION_NAME] . 
     
     
 .. _sync-endpoint-dhis2:    
@@ -247,7 +256,7 @@ Managing Identity through DHIS2
 
     After restarting your Sync Endpoint server, you will be able to login to Sync Endpoint using the same credentials you use
     for your DHIS2 server. DHIS2 organization units and groups, with membership preserved, will be converted to Sync Endpoint
-    groups and accesible through the Sync Endpoint REST API.\
+    groups and accessible through the Sync Endpoint REST API.\
     
 .. _sync-endpoint-warnings:
 
@@ -255,7 +264,7 @@ Warnings
 --------
  - The database and the LDAP directory set up here are meant only for testing and evaluation. When running in production you should configure a production ready 
    database and a production ready LDAP directory. Using the pre-configured database and directory in production can result in poor performance and degraded 
-   availabiltiy.
+   availabilitiy.
  - You should refer to Docker Swarm documentation on running a production ready Swarm.
  - We recommend that you host Sync Endpoint on a commercial cloud provider (e.g. Google Cloud Platform, Amazon AWS, Microsoft Azure, etc.) If you want to host 
    Sync Endpoint on premise, you should consult your System Administrator for appropriate hardware.

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -79,14 +79,14 @@ If you'd prefer to use the :program:`OpenLDAP` command line utilities, they're i
   - Linux/macOS:
 
   .. code-block:: console
- 
-    $ docker exec $(docker ps -f "label=com.docker.swarm.service.name=syncldap_ldap-service" --format '{{.ID}}') LDAPTOOL ARGS
+
+   $ docker exec $(docker ps -f "label=com.docker.swarm.service.name=syncldap_ldap-service" --format '{{.ID}}') LDAPTOOL ARGS
 
   - Windows:
 
   .. code-block:: console
 
-    $ docker exec (docker ps -f "label=com.docker.swarm.service.name=syncldap_ldap-service" --format '{{.ID}}') LDAPTOOL ARGS
+   $ docker exec (docker ps -f "label=com.docker.swarm.service.name=syncldap_ldap-service" --format '{{.ID}}') LDAPTOOL ARGS
 
 .. note::
 
@@ -143,21 +143,7 @@ Assigning users to groups
 
     a. Navigate to the :guilabel:`memberUid` section.
     b. Click modify group members to manage members.
-    
-.. _sync-endpoint-ldap-utils:
 
-Using LDAP utils
-"""""""""""""""""""""""""
-
-  The ldap-service container has ldap-utils installed. If you'd prefer, you may use that tool set to administer the LDAP directory as well. Use this command to
-  access them,
- 
-    .. code-block:: console
-  
-     $ docker exec $(docker ps -f "label=com.docker.swarm.service.name=${STACK_NAME}_sync" --format '{{.ID}}') <LDAPTOOL> <ARGS>
-     
-    The docker exec takes a container name and a command . The command is executed in the specified container . 
-    
 .. _sync-endpoint-advanced:
 
 Advanced
@@ -165,59 +151,83 @@ Advanced
 
 .. _sync-endpoint-ldap-defaults:
 
-Editing the defaults of LDAP directory
+Editing the defaults of LDAP Directory
 """""""""""""""""""""""""""""""""""""""""""""
-    Modify the ldap.env file to configure the environment variables . The default settings are as follows 
-    
-      .. code-block:: console
-      
-       # openldap
-       LDAP_ORGANISATION=Open Data Kit            // name of your organisation
-       LDAP_DOMAIN=example.org                    // domain of your organisation
-       LDAP_READONLY_USER=true                    // enable the read only user
-       LDAP_READONLY_USER_PASSWORD=readonly       // password for read only user
-       LDAP_ADMIN_PASSWORD=admin                  // default password for admin account 
+    Modify the :file:`ldap.env` file to configure the environment variables. The :file:`ldap.env` file is located in the sync-endpoint-default-setup diretory.
 
-       # phpldapadmin
-       PHPLDAPADMIN_LDAP_HOSTS=ldap-service   // This is for the phpLDAPadmin . In docker swarm this is the name of the service running LDAP . This can be eddited
-                                                 in the docker-compose.yml file
-                                                 
-   
+    The default settings are as follows 
+
+     .. code-block:: console
+
+      # openldap
+      LDAP_ORGANISATION=Open Data Kit            // name of your organisation
+      LDAP_DOMAIN=example.org                    // domain of your organisation
+      LDAP_READONLY_USER=true                    // enable the read only user
+      LDAP_READONLY_USER_PASSWORD=readonly       // password for read only user
+      LDAP_ADMIN_PASSWORD=admin                  // default password for admin account
+
+      # phpldapadmin
+      PHPLDAPADMIN_LDAP_HOSTS=ldap-service   // This is for the phpLDAPadmin . In Docker Swarm this is the hostname of the service running LDAP . This can be 
+                                                eddited in the docker-compose.yml file
+
+
+  .. note::
+
+    For LDAP environment variables the corresponding options in the security.properties also need to be modified . The security.properties file is
+    located at config/sync-endpoint in the sync-endpoint-default-setup directory.
+
+
 .. _sync-endpoint-custom-ldap:
 
-Using a Different LDAP directory
+Using a Different LDAP Directory
 """"""""""""""""""""""""""""""""""""""""""""""
-    
-    1. Create a folder in the sync-endpoint-default-setup directory and create a docker file inside it .
-    
-    2. Copy the bootstrap.ldif file from the OpenLDAP directory to the new directory .In the docker file Add the image of the ldap directory to be used and add 
+
+    1. Create a new directory in the sync-endpoint-default-setup directory and create a Docker file inside it .
+
+    2. Copy the bootstrap.ldif file from the OpenLDAP directory to the new directory .In the Docker file Add the image of the LDAP Directory to be used and add 
        the "COPY" command to copy the bootstrap.ldif file to the right path in the container .
-    
-    3. Run the following command to build the docker image :
-    
+
+    3. Run the following command to build the Docker image :
+
      .. code-block:: console
-  
-       $ docker build -t odk/[LDAP_DIRECTORY_NAME] [ Folder conatining the docker file ]
-       
+
+       $ docker build -t odk/[LDAP_DIRECTORY_NAME] [ Folder conatining the Docker file ]
+
     4. Replace the ldap-service image from docker-compose.yml with odk/[LDAP_DIRECTORY_NAME].
-    
-    5. Modify config/sync-endpoint/security.properties to fill in the Settings for LDAP server.
-       Set security.server.ldapUrl in security.properties to the new server url . The name of the service in swarm would be same ( ldap-service ) . So just change 
-       the port number .
-    
+
+    5. In the sync-endpoint-default-setup directory navigate to config/sync-endpoint. Modify the :file:`security.properties` file to fill in the Settings for LDAP 
+       server.Set security.server.ldapUrl in security.properties to the new server url . The name of the service in Swarm would be same ( ldap-service ) . So just 
+       change the port number. After this following settings need to be configured in the same file for the LDAP server :
+
+       - :guilabel:`security.server.ldapBaseDn`
+       - :guilabel:`security.server.ldapPooled`
+       - :guilabel:`security.server.userSearchBase`
+       - :guilabel:`security.server.groupSearchBase`
+       - :guilabel:`security.server.groupRoleAttribute`
+       - :guilabel:`security.server.userFullnameAttribute`
+       - :guilabel:`security.server.usernameAttribute`
+       - :guilabel:`security.server.userDnPattern`
+       - :guilabel:`security.server.memberOfGroupSearchFilter`
+       - :guilabel:`security.server.serverGroupSearchFilter`
+
+.. note::
+
+  The LDAP Directory here is configured to run inside the Docker Swarm. If you are running the LDAP Directory outside the Docker Swarm and it is accessible 
+  for the containers inside the Docker Swarm , you can directly follow step 5 to configure it .
+
 .. _sync-endpoint-ldap-ui:
 
 Using a Different LDAP UI
 """"""""""""""""""""""""""""""""""""""""""""""
-    
-    If you want to use a UI outside the docker swarm in your local machine Modify the docker-compose.yml file in sync-endpoint-default-setup directory . Add ports 
+
+    If you want to use a UI outside the Docker Swarm in your local machine Modify the docker-compose.yml file in sync-endpoint-default-setup directory . Add ports 
     mapping to the ldap service to expose the port 389 of ldap service to a port in your local host . If you wish to access 
     the ldap protocol over TLS/SSL expose the port 636. Connect the UI application to this port on localhost.
-    
-    The ldap service of the the docker compose should be like this after adding port mapping .
-    
+
+    The ldap service of the the Docker compose should be like this after adding port mapping .
+
     .. code-block:: console
-        
+
       ldap-service:
        image: odk/openldap
        deploy:
@@ -231,39 +241,53 @@ Using a Different LDAP UI
         - ldap-slapd.d-vol:/etc/ldap/slapd.d
        env_file:
         - ldap.env 
-    
-    
-    For running the UI application in the docker swarm create a folder in the sync-endpoint-default-setup directory and create a docker file inside it .
-    Copy the templates folder from the phpLDAPadmin directory to the new directory . In the docker file ,add the image of the UI application to be used and the 
+
+    .. Warning:: The LDAP service running at any port will not only be accessible from the localhost but will also be exposed over the Docker ingress overlay 
+                 network (which is exposed to the Internet in most cases).
+
+    For running the UI application in the Docker Swarm create a folder in the sync-endpoint-default-setup directory and create a Docker file inside it .
+    Copy the templates folder from the phpLDAPadmin directory to the new directory . In the Docker file ,add the image of the UI application to be used and the 
     "COPY" command to copy the templates folder to the right path inside the container .
-    
-    To build the docker image run the command in the sync-endpoint-default-setup-directory with tag odk/[YOUR_UI_APPLICATION_NAME] :
-    
+
+    To build the Docker image run the command in the sync-endpoint-default-setup-directory with tag odk/[YOUR_UI_APPLICATION_NAME] :
+
      .. code-block:: console
-  
-       $ docker build -t odk/[YOUR_UI_APPLICATION_NAME] [ Folder conatining the docker file ]
-       
+
+       $ docker build -t odk/[YOUR_UI_APPLICATION_NAME] [ Folder conatining the Docker file ]
+
     Edit the docker-compose.yml file . Replace the image of phpLDAPadmin service with odk/[YOUR_UI_APPLICATION_NAME] . 
-    
-    
+
 .. _sync-endpoint-dhis2:    
 
 Managing Identity through DHIS2
 """""""""""""""""""""""""""""""""
-    Modify config/sync-endpoint/security.properties to fill in the Settings for DHIS2 Authentication section
-    Set security.server.authenticationMethod in security.properties to dhis2
-    [OPTIONAL] Remove OpenLDAP and phpLDAPadmin from docker-compose.yml .
+   In the sync-endpoint-default-setup directory navigate to config/sync-endpoint. Modify the :file:`security.properties` file to fill in the Settings for DHIS2 
+   Authentication section. Set security.server.authenticationMethod in security.properties to dhis2. After this the following settings need to be configured for
+   dhis2.
 
-    After restarting your Sync Endpoint server, you will be able to login to Sync Endpoint using the same credentials you use
-    for your DHIS2 server. DHIS2 organization units and groups, with membership preserved, will be converted to Sync Endpoint
-    groups and accessible through the Sync Endpoint REST API.\
-    
+       - :guilabel:`security.server.dhis2ApiUrl`
+       - :guilabel:`security.server.dhis2AdminUsername`
+       - :guilabel:`security.server.dhis2AdminPassword`
+       - :guilabel:`security.server.dhis2SiteAdmins`
+       - :guilabel:`security.server.dhis2AdministerTables`
+       - :guilabel:`security.server.dhis2SuperUserTables`
+       - :guilabel:`security.server.dhis2SyncTables`
+       - :guilabel:`security.server.dhis2FormManagers`
+       - :guilabel:`security.server.dhis2DataViewers`
+       - :guilabel:`security.server.dhis2DataCollectors`
+
+   [OPTIONAL] Remove OpenLDAP and phpLDAPadmin from docker-compose.yml .
+
+   After restarting your Sync Endpoint server, you will be able to login to Sync Endpoint using the same credentials you use
+   for your DHIS2 server. DHIS2 organization units and groups, with membership preserved, will be converted to Sync Endpoint
+   groups and accessible through the Sync Endpoint REST API.
+
 .. _sync-endpoint-warnings:
 
 Warnings
 --------
- - The database and the LDAP directory set up here are meant only for testing and evaluation. When running in production you should configure a production ready 
-   database and a production ready LDAP directory. Using the pre-configured database and directory in production can result in poor performance and degraded 
+ - The database and the LDAP Directory set up here are meant only for testing and evaluation. When running in production you should configure a production ready 
+   database and a production ready LDAP Directory. Using the pre-configured database and directory in production can result in poor performance and degraded 
    availability.
  - You should refer to Docker Swarm documentation on running a production ready Swarm.
  - We recommend that you host Sync Endpoint on a commercial cloud provider (e.g. Google Cloud Platform, Amazon AWS, Microsoft Azure, etc.) If you want to host 

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -159,6 +159,7 @@ Editing the defaults of LDAP directory
     Modify the ldap.env file to configure the environment variables . The default settings are as follows 
     
       .. code-block:: console
+      
        # openldap
        LDAP_ORGANISATION=Open Data Kit            // name of your organisation
        LDAP_DOMAIN=example.org                    // domain of your organisation

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -167,13 +167,13 @@ Editing the defaults of LDAP Directory
       LDAP_ADMIN_PASSWORD=admin                  // default password for admin account
 
       # phpldapadmin
-      PHPLDAPADMIN_LDAP_HOSTS=ldap-service   // This is for the phpLDAPadmin . In Docker Swarm this is the hostname of the service running LDAP . This can be 
+      PHPLDAPADMIN_LDAP_HOSTS=ldap-service   // This is for the phpLDAPadmin. In Docker Swarm this is the hostname of the service running LDAP. This can be 
                                                 eddited in the docker-compose.yml file
 
 
   .. note::
 
-    For LDAP environment variables the corresponding options in the security.properties also need to be modified . The security.properties file is
+    For LDAP environment variables the corresponding options in the security.properties also need to be modified. The security.properties file is
     located at config/sync-endpoint in the sync-endpoint-default-setup directory.
 
 .. _sync-endpoint-ldap-ui:
@@ -181,11 +181,11 @@ Editing the defaults of LDAP Directory
 Using a Different LDAP UI
 """"""""""""""""""""""""""""""""""""""""""""""
 
-    If you want to use a UI outside the Docker Swarm in your local machine Modify the docker-compose.yml file in sync-endpoint-default-setup directory . Add ports 
-    mapping to the ldap service to expose the port 389 of ldap service to a port in your local host . If you wish to access 
+    If you want to use a UI outside the Docker Swarm in your local machine Modify the docker-compose.yml file in sync-endpoint-default-setup directory. Add ports 
+    mapping to the ldap service to expose the port 389 of ldap service to a port in your local host. If you wish to access 
     the ldap protocol over TLS/SSL expose the port 636. Connect the UI application to this port on localhost.
 
-    The ldap service of the the Docker compose should be like this after adding port mapping .
+    The ldap service of the the Docker compose should be like this after adding port mapping.
 
     .. code-block:: console
 
@@ -206,17 +206,17 @@ Using a Different LDAP UI
     .. Warning:: The LDAP service running at any port will not only be accessible from the localhost but will also be exposed over the Docker ingress overlay 
                  network (which is exposed to the Internet in most cases).
 
-    For running the UI application in the Docker Swarm create a folder in the sync-endpoint-default-setup directory and create a Docker file inside it .
-    Copy the templates folder from the phpLDAPadmin directory to the new directory . In the Docker file ,add the image of the UI application to be used and the 
-    "COPY" command to copy the templates folder to the right path inside the container .
+    For running the UI application in the Docker Swarm create a folder in the sync-endpoint-default-setup directory and create a Docker file inside it.
+    Copy the templates folder from the phpLDAPadmin directory to the new directory. In the Docker file ,add the image of the UI application to be used and the 
+    "COPY" command to copy the templates folder to the right path inside the container.
 
-    To build the Docker image run the command in the sync-endpoint-default-setup-directory with tag odk/[YOUR_UI_APPLICATION_NAME] :
+    To build the Docker image run the command in the sync-endpoint-default-setup-directory with tag odk/[YOUR_UI_APPLICATION_NAME]:
 
      .. code-block:: console
 
        $ docker build -t odk/[YOUR_UI_APPLICATION_NAME] [ Folder conatining the Docker file ]
 
-    Edit the docker-compose.yml file . Replace the image of phpLDAPadmin service with odk/[YOUR_UI_APPLICATION_NAME] . 
+    Edit the docker-compose.yml file. Replace the image of phpLDAPadmin service with odk/[YOUR_UI_APPLICATION_NAME]. 
 
 .. _sync-endpoint-dhis2:    
 

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -176,45 +176,6 @@ Editing the defaults of LDAP Directory
     For LDAP environment variables the corresponding options in the security.properties also need to be modified . The security.properties file is
     located at config/sync-endpoint in the sync-endpoint-default-setup directory.
 
-
-.. _sync-endpoint-custom-ldap:
-
-Using a Different LDAP Directory
-""""""""""""""""""""""""""""""""""""""""""""""
-
-    1. Create a new directory in the sync-endpoint-default-setup directory and create a Docker file inside it .
-
-    2. Copy the bootstrap.ldif file from the OpenLDAP directory to the new directory .In the Docker file Add the image of the LDAP Directory to be used and add 
-       the "COPY" command to copy the bootstrap.ldif file to the right path in the container .
-
-    3. Run the following command to build the Docker image :
-
-     .. code-block:: console
-
-       $ docker build -t odk/[LDAP_DIRECTORY_NAME] [ Folder conatining the Docker file ]
-
-    4. Replace the ldap-service image from docker-compose.yml with odk/[LDAP_DIRECTORY_NAME].
-
-    5. In the sync-endpoint-default-setup directory navigate to config/sync-endpoint. Modify the :file:`security.properties` file to fill in the Settings for LDAP 
-       server.Set security.server.ldapUrl in security.properties to the new server url . The name of the service in Swarm would be same ( ldap-service ) . So just 
-       change the port number. After this following settings need to be configured in the same file for the LDAP server :
-
-       - :guilabel:`security.server.ldapBaseDn`
-       - :guilabel:`security.server.ldapPooled`
-       - :guilabel:`security.server.userSearchBase`
-       - :guilabel:`security.server.groupSearchBase`
-       - :guilabel:`security.server.groupRoleAttribute`
-       - :guilabel:`security.server.userFullnameAttribute`
-       - :guilabel:`security.server.usernameAttribute`
-       - :guilabel:`security.server.userDnPattern`
-       - :guilabel:`security.server.memberOfGroupSearchFilter`
-       - :guilabel:`security.server.serverGroupSearchFilter`
-
-.. note::
-
-  The LDAP Directory here is configured to run inside the Docker Swarm. If you are running the LDAP Directory outside the Docker Swarm and it is accessible 
-  for the containers inside the Docker Swarm , you can directly follow step 5 to configure it .
-
 .. _sync-endpoint-ldap-ui:
 
 Using a Different LDAP UI

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -153,7 +153,7 @@ Advanced
 
 Editing the defaults of LDAP Directory
 """""""""""""""""""""""""""""""""""""""""""""
-    Modify the :file:`ldap.env` file to configure the environment variables. The :file:`ldap.env` file is located in the sync-endpoint-default-setup diretory.
+    Modify the :file:`ldap.env` file to configure the environment variables. The :file:`ldap.env` file is located in the sync-endpoint-default-setup directory.
 
     The default settings are as follows 
 

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -146,6 +146,8 @@ Using LDAP utils
     .. code-block:: console
   
      $ docker exec $(docker ps -f "label=com.docker.swarm.service.name=${STACK_NAME}_sync" --format '{{.ID}}') <LDAPTOOL> <ARGS>
+     
+    The docker exec takes a container name and a command . The command is executed in the sepcified container . 
     
 .. _sync-endpoint-advanced:
 
@@ -178,8 +180,9 @@ Using a Different LDAP directory
 """"""""""""""""""""""""""""""""""""""""""""""
     
     1. Create a folder in the sync-endpoint-default-setup directory and create a docker file inside it .
+    
     2. Copy the bootstrap.ldif file from the OpenLDAP directory to the new directory .In the docker file Add the image of the ldap directory to be used and add 
-       the copy command to copy the bootstrap.ldif file to the right location in the container .
+       the "COPY" command to copy the bootstrap.ldif file to the right path in the container .
     
     3. Run the following command to build the docker image :
     
@@ -191,7 +194,7 @@ Using a Different LDAP directory
     
     5. Modify config/sync-endpoint/security.properties to fill in the Settings for LDAP server.
        Set security.server.ldapUrl in security.properties to the new server url . The name of the service in swarm would be same ( ldap-service ) . So just change 
-       the port number . For OpenLDAP port is 389 so url is ldap://ldap-service:389 .
+       the port number .
     
 .. _sync-endpoint-ldap-ui:
 
@@ -199,9 +202,9 @@ Using a Different LDAP UI
 """"""""""""""""""""""""""""""""""""""""""""""
     
     If you want to use a UI outside the docker swarm in your local machine Modify the docker-compose.yml file in sync-endpoint-default-setup directory . Add ports 
-    mapping to the ldap service to expose the port 389 of ldap service to any port in your local host . Connect the UI application to this port on localhost.
+    mapping to the ldap service to expose the port 389 of ldap service to a port in your local host . Connect the UI application to this port on localhost.
     
-    The ldap service of the the docker compose should be like this 
+    The ldap service of the the docker compose should be like this after adding port mapping .
     
     .. code-block:: console
         
@@ -221,8 +224,8 @@ Using a Different LDAP UI
     
     
     For running the UI application in the docker swarm create a folder in the sync-endpoint-default-setup directory and create a docker file inside it .
-    Copy the bootstrap.ldif file from the OpenLDAP directory to the new directory . Add the image of the UI application to be used and the copy command to copy 
-    the bootstrap.ldif file to the right location in the container .
+    Copy the templates folder from the phpLDAPadmin directory to the new directory . In the docker file ,add the image of the UI application to be used and the 
+    "COPY" command to copy the templates folder to the right path inside the container .
     
     To build the docker image run the command in the sync-endpoint-default-setup-directory with tag odk/[YOUR_UI_APPLICATION_NAME] :
     

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -143,9 +143,9 @@ Using LDAP utils
   The ldap-service container has ldap-utils installed. If you'd prefer, you may use that toolset to administer the LDAP directory as well. Use this command to
   access them,
  
- .. code-block:: console
+    .. code-block:: console
   
-    $ docker exec $(docker ps -f "label=com.docker.swarm.service.name=${STACK_NAME}_sync" --format '{{.ID}}') <LDAPTOOL> <ARGS>
+     $ docker exec $(docker ps -f "label=com.docker.swarm.service.name=${STACK_NAME}_sync" --format '{{.ID}}') <LDAPTOOL> <ARGS>
     
 .. _sync-endpoint-advanced:
 
@@ -158,16 +158,16 @@ Editing the defaults of LDAP directory
 """""""""""""""""""""""""""""""""""""""""""""
     Modify the ldap.env file to configure the environment variables . The default settings are as follows 
     
-   .. code-block:: console
-     # openldap
-     LDAP_ORGANISATION=Open Data Kit            // name of your organisation
-     LDAP_DOMAIN=example.org                    // domain of your organisation
-     LDAP_READONLY_USER=true                    // enable the read only user
-     LDAP_READONLY_USER_PASSWORD=readonly       // password for read only user
-     LDAP_ADMIN_PASSWORD=admin                  // default password for admin account 
+      .. code-block:: console
+       # openldap
+       LDAP_ORGANISATION=Open Data Kit            // name of your organisation
+       LDAP_DOMAIN=example.org                    // domain of your organisation
+       LDAP_READONLY_USER=true                    // enable the read only user
+       LDAP_READONLY_USER_PASSWORD=readonly       // password for read only user
+       LDAP_ADMIN_PASSWORD=admin                  // default password for admin account 
 
-     # phpldapadmin
-     PHPLDAPADMIN_LDAP_HOSTS=ldap-service   // ldap-service is the host of OpenLDAP . This is for the phpLDAPadmin
+       # phpldapadmin
+       PHPLDAPADMIN_LDAP_HOSTS=ldap-service   // ldap-service is the host of OpenLDAP . This is for the phpLDAPadmin
    
 .. _sync-endpoint-custom-ldap:
 

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -158,7 +158,7 @@ Editing the defaults of LDAP directory
 """""""""""""""""""""""""""""""""""""""""""""
     Modify the ldap.env file to configure the environment variables . The default settings are as follows 
     
-    .. code-block:: console
+   .. code-block:: console
      # openldap
      LDAP_ORGANISATION=Open Data Kit            // name of your organisation
      LDAP_DOMAIN=example.org                    // domain of your organisation


### PR DESCRIPTION
Whats included in this pr ?

Documentation for how to configure the defaults of OpenLDAP .
Documentation for how to use another LDAP UI to access the OpenLDAP .
Documentation for how to change Sync-Endpoint to use/access a different LDAP than the OpenLDAP in the Docker swarm .
Documentation for using LDAP utils .

Should fix https://github.com/odk-x/tool-suite-X/issues/145