### PR TITLE
Fix #174: Add signature prompt type and fix survey prompt type URL in docs

### DIFF
--- a/odkx-src/xlsx-converter-reference.rst
+++ b/odkx-src/xlsx-converter-reference.rst
@@ -376,8 +376,7 @@ The following prompt types are available in ODK-X Survey.
       | choices provided is an other option which if clicked provides a text
       | box for the user to enter a value.
   * - signature
-    - | Used to capture the user signature and allows them to enter a signature
-      | by tracing with the finger.
+    - | Used to capture a signature by tracing on the device screen.
   * - string
     - | Used to ask the user a question and allows them to enter a string.
   * - text

--- a/odkx-src/xlsx-converter-reference.rst
+++ b/odkx-src/xlsx-converter-reference.rst
@@ -310,6 +310,7 @@ The following prompt types are available in ODK-X Survey.
 
 .. list-table:: Survey Prompt Types
   :header-rows: 1
+  :name: survey-prompt-types
 
   * - Prompt Type
     - | Description
@@ -374,6 +375,9 @@ The following prompt types are available in ODK-X Survey.
       | to the user, and allows the user to click one item. One of the
       | choices provided is an other option which if clicked provides a text
       | box for the user to enter a value.
+  * - signature
+    - | Used to capture the user signature and allows them to enter a signature
+      | by tracing with the finger.
   * - string
     - | Used to ask the user a question and allows them to enter a string.
   * - text

--- a/run-task.bat
+++ b/run-task.bat
@@ -1,1 +1,1 @@
-docker run --rm -v "%~dp0:/mnt" -p 8080:8080 --name odkx-docs odkx-docs %1
+docker run --rm -v %~dp0:/mnt -p 8080:8080 --name odkx-docs odkx-docs %1

--- a/run-task.bat
+++ b/run-task.bat
@@ -1,1 +1,1 @@
-docker run --rm -v %~dp0:/mnt -p 8080:8080 --name odkx-docs odkx-docs %1
+docker run --rm -v "%~dp0:/mnt" -p 8080:8080 --name odkx-docs odkx-docs %1


### PR DESCRIPTION
Add signature prompt type and fix survey prompt type URL in docs docs

<!-- If this PR is related to an open issue -->
closes odk-x/tool-suite-X#174
<!-- OR -->
<!-- addresses odk-x/tool-suite-X#-->


#### What is included in this PR?
1. URL [https://docs.odk-x.org/xlsx-converter-reference/#id4](https://docs.odk-x.org/xlsx-converter-reference/#id4) improved to [https://docs.odk-x.org/xlsx-converter-reference/#survey-prompt-types](https://docs.odk-x.org/xlsx-converter-reference/#survey-prompt-types) 
2. Signature prompt type and description added to Survey Prompt Types list.



<!-- Answer any that apply and delete the others. -->
<!-- #### What new issues will need to be opened because of this PR?-->

<!-- #### What is left to be done in the addressed issue?-->

#### What problems did you encounter?
I built and served the cloned repository with Docker, I noticed that when I ran `.\run-task.bat odkx-autobuild`  it returned  `docker: invalid reference format`. I was tinkering around in the `run-task.bat` file and found out that when I added double quotes around `'%~dp0:/mnt'` , the problem was solved. I spoke to the mentors and @wbrunette asked that I include this in the Pull Request with the Windows Version.
