### PR TITLE
Add double quotes to run-task.bat file

### DIFF
--- a/run-task.bat
+++ b/run-task.bat
@@ -1,1 +1,1 @@
-docker run --rm -v %~dp0:/mnt -p 8080:8080 --name odkx-docs odkx-docs %1
+docker run --rm -v "%~dp0:/mnt" -p 8080:8080 --name odkx-docs odkx-docs %1


### PR DESCRIPTION
Add double quotes to run-task.bat file

After getting the `docker: invalid reference format` a few time after I ran `.\run-task.bat odkx-autobuild`. I got the idea to add quotes because there is a space in the file path `C:\Users\Temenu Esther-Phebe\odk\odk-x-docs>` . Adding single quotes `'%~dp0:/mnt'` to the run-task.bat file gave me the same output (`docker: invalid reference format`) while adding double quotes `"%~dp0:/mnt"`  started the build and serve process on **Windows 10 Pro, Version 20H2 (OS Build 19042.804)**

#### What is included in this PR?
1. Change in run-task.bat file from `docker run --rm -v %~dp0:/mnt -p 8080:8080 --name odkx-docs odkx-docs %1` to double quotes around `"%~dp0:/mnt"` `docker run --rm -v "%~dp0:/mnt" -p 8080:8080 --name odkx-docs odkx-docs %1` 


<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?
There is a need to find out whether the `docker: invalid reference format` output is due to the Windows Version or the space in the file path.


