### PR TITLE
Add documentation for spell check

### DIFF
--- a/odkx-src/docs-developer-guide.rst
+++ b/odkx-src/docs-developer-guide.rst
@@ -341,6 +341,19 @@ specify the check name in the check list
 in the function :py:func:`exclude_checks`
 in the file :file:`style-test.py`.
 
+Excluding Spelling checks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To exclude a word from spelling check,
+specify the word under the title spelling.
+Example:
+
+  .. code-block:: console
+
+    .. spelling::
+      phpLDAPadmin
+      readonly
+      letsencrypt
 
 
 

--- a/odkx-src/docs-developer-guide.rst
+++ b/odkx-src/docs-developer-guide.rst
@@ -344,8 +344,7 @@ in the file :file:`style-test.py`.
 Excluding Spelling checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To exclude a word from spelling check,
-specify the word under the title spelling.
+To exclude a word from spelling check,specify the word under the title spelling on the top of the document.
 Example:
 
   .. code-block:: console


### PR DESCRIPTION
Documentation to exclude a word from spelling check is added.
fix https://github.com/odk-x/tool-suite-X/issues/247
