### PR TITLE
Document showFooter and showHeader options for Survey forms

### DIFF
--- a/odkx-src/xlsx-converter-reference.rst
+++ b/odkx-src/xlsx-converter-reference.rst
@@ -482,6 +482,16 @@ Available :th:`setting_name` values that can be used:
     - | Optional
     - | Used with :th:`display.prompt.text.<language>`, or
       | other fiels to set other language options in the form.
+  * - showHeader
+    - | Optional
+    - | Used to display the header at the top of every page of the form.
+      | Shows the form title in a navigation bar with Back and Next buttons.
+      | The form header is visible by default.
+  * - showFooter
+    - | Optional
+    - | Used to display a navigation bar at the bottom of 
+      | every page of the form. Similar to the header with Back
+      | and Next buttons. The form footer is hidden by default.
 
 A sample **settings** worksheet might look like this:
 
@@ -519,6 +529,11 @@ A sample **settings** worksheet might look like this:
     -
     - Hindi
     - Hindi (as Hindi name)
+  * - showFooter
+    - TRUE
+    -
+    - 
+    - 
 
 .. tip::
 


### PR DESCRIPTION
closes odk-x/tool-suite-X#189

#### What is included in this PR?
added new rows in the [setting_name values](https://docs.odk-x.org/xlsx-converter-reference/#setting-name-value) table to describe the showHeader and showFooter options. also included a row for showFooter in the settings worksheet example with value TRUE (because that was how I tried it out to see what that setting did). for reference here is what the form looked like with those settings: 
![image](https://user-images.githubusercontent.com/70604078/115290853-07fe5300-a122-11eb-9e79-8e6680bbd135.png)




<!-- Answer any that apply and delete the others. -->
#### What is left to be done in the addressed issue?
kindly review the additions and let me know how I can improve it. for example, I wasn't sure how to refer to the "Back and Next buttons" so I called them that.

#### What problems did you encounter?
I was following the [guide ](https://docs.odk-x.org/docs-tech-guide/#working-on-the-docs)on setting up and building the docs because this was my first time and I encountered a problem with running the checks locally using the commands provided so I will be creating an issue to address that
