### PR TITLE
Update spelling_wordlist.txt

### DIFF
--- a/odkx-src/spelling_wordlist.txt
+++ b/odkx-src/spelling_wordlist.txt
@@ -250,6 +250,7 @@ Screenshots
 screenshots
 scriptable
 sdcard
+sdkmanager
 selectable
 selectionArgs
 selfie


### PR DESCRIPTION
#### What is included in this PR?

Add the word 'sdkmanager'. This is so that a different pull request on the docs can pass the CircleCi spell check, which is failing because of the presence of the word 'sdkmanager'.