### PR TITLE
Fix link to rest protocol

### DIFF
--- a/odkx-src/aggregate-tables-extension.rst
+++ b/odkx-src/aggregate-tables-extension.rst
@@ -7,7 +7,7 @@ ODK Aggregate Tables Extension
 
 :dfn:`ODK Aggregate Tables Extensions` enable the ODK-X tools to share data via bi-directional synchronization with a central ODK Aggregate server. However, this approach is no longer supported, please migrate to :doc:`sync-endpoint`.
 
-The `ODK-X REST Protocol <https://github.com/odk-x/odk-x/wiki/ODK-2.0-Synchronization-API-(RESTful)>`_ is compatible with ODK Aggregate v1.4.15. The sync protocol has been augmented to cache the user's permissions on the device and, for super-users or administrators, to cache the full set of users and all of their permissions (so that the super-user and/or administrator can assign rows to particular individuals).
+The `ODK-X REST Protocol <https://docs.odk-x.org/odk-2-sync-protocol/>`_ is compatible with ODK Aggregate v1.4.15. The sync protocol has been augmented to cache the user's permissions on the device and, for super-users or administrators, to cache the full set of users and all of their permissions (so that the super-user and/or administrator can assign rows to particular individuals).
 
 .. _aggregate-tables-extension-server-setup:
 

--- a/odkx-src/cloud-endpoints-intro.rst
+++ b/odkx-src/cloud-endpoints-intro.rst
@@ -3,7 +3,7 @@ ODK-X Cloud Endpoints
 
 .. _cloud-endpoints-intro:
 
-:dfn:`ODK-X Cloud Endpoints` are servers that communicate with the ODK-X Android applications. They implement the `ODK-X REST Protocol <https://github.com/odk-x/odk-x/wiki/ODK-2.0-Synchronization-API-(RESTful)>`_.
+:dfn:`ODK-X Cloud Endpoints` are servers that communicate with the ODK-X Android applications. They implement the `ODK-X REST Protocol <https://docs.odk-x.org/odk-2-sync-protocol/>`_.
 
 There are currently two options for Cloud Endpoints to communicate with ODK-X tools.
 


### PR DESCRIPTION
<!-- If this PR is related to an open issue -->

addresses odk-x/tool-suite-X#207


#### What is included in this PR?

Fixes the link for ODK-X REST Protocol on page: https://docs.odk-x.org/sync-endpoint/ and https://docs.odk-x.org/aggregate-tables-extension/

