### PR TITLE
Sync endpoint user instruction

### DIFF
--- a/odkx-src/index.rst
+++ b/odkx-src/index.rst
@@ -162,6 +162,7 @@ The :doc:`tables-sample-app` walks you through the process of using a basic tabl
   sync-endpoint
   sync-endpoint-cloud-setup
   sync-endpoint-manual-setup
+  sync-endpoint-user-instructions.rst
   aggregate-tables-extension
 
 .. toctree::

--- a/odkx-src/sync-endpoint-cloud-setup.rst
+++ b/odkx-src/sync-endpoint-cloud-setup.rst
@@ -550,7 +550,6 @@ Connecting to your virtual machine
 
 9. After going through the instructions for *Creating a Sample User,* we no longer need access to this admin interface anymore. This admin interface is running on port 40000, and in order to ensure that this admin interface is not publicly accessible to anyone, we want to remove the rule that accepts incoming traffic to that port. We do this the same way we added the rules above.
 
-
 .. _sync-endpoint-setup-aws-launch:
 
 Launching the ODK-X Server

--- a/odkx-src/sync-endpoint-cloud-setup.rst
+++ b/odkx-src/sync-endpoint-cloud-setup.rst
@@ -561,14 +561,14 @@ Launching the ODK-X Server
   .. image:: /img/setup-azure/azure11.png
    :width: 600
 
-  .. note::
+.. note::
     If you are unable to log in, you may need to take the docker stack down and bring it back up again. That can be done with the following commands below:
 
-  .. code-block:: console
+.. code-block:: console
 
     $ docker stack rm syncldap
 
-  .. code-block:: console
+.. code-block:: console
 
     $ docker stack deploy -c /root/sync-endpoint-default-setup/docker-compose.yml syncldap
 

--- a/odkx-src/sync-endpoint-cloud-setup.rst
+++ b/odkx-src/sync-endpoint-cloud-setup.rst
@@ -561,9 +561,6 @@ Launching the ODK-X Server
   .. image:: /img/setup-azure/azure11.png
    :width: 600
 
-  Once a user has been created in the admin interface, this is the login screen that the user will use to log in and access their data.
-
-
   .. note::
     If you are unable to log in, you may need to take the docker stack down and bring it back up again. That can be done with the following commands below:
 

--- a/odkx-src/sync-endpoint-cloud-setup.rst
+++ b/odkx-src/sync-endpoint-cloud-setup.rst
@@ -563,52 +563,6 @@ Launching the ODK-X Server
 
   Once a user has been created in the admin interface, this is the login screen that the user will use to log in and access their data.
 
-.. _sync-endpoint-setup-create-user:
-
-Creating a Sample User
-----------------------
-
-| 1. Start by logging into the ldap-service. Copy the login below.
-|   - login DN: :guilabel:`cn=admin,dc=example,dc=org`
-|   - password: :guilabel:`admin`
-
-    .. image:: /img/setup-create-user/setup-user1.png
-      :width: 600
-
-2. Click the :guilabel:`+` sign next to **dc=example, dc=org** to expand it. Within the unfolded menu, in the **ou=people** section, click on :guilabel:`Create a child entry` (new person).
-
-  .. image:: /img/setup-create-user/setup-user2.png
-    :width: 600
-
-3. Then, select the :guilabel:`Generic: User Account` template.
-
-  .. image:: /img/setup-create-user/setup-user3.png
-    :width: 600
-
-4. Fill out information for the new user and “create object.” Assign it to the *default_prefix_synchronize_tables* group. Will need to commit (confirm) that you want to create this entry on the next screen.
-
-  .. image:: /img/setup-create-user/setup-user4.png
-    :width: 600
-
-  We have now created the user! We just need to add the user to the respective group from the group settings.
-
-5. Click the :guilabel:`+` sign next **ou=groups** to expand it. Within the unfolded menu, in the **ou=default_prefix** section, click on :guilabel:`gidNumber=503`, which is the group ID that corresponds to *default_prefix_synchronize_tables*. Groups correspond to the access permissions available to a certain user.
-
-  .. image:: /img/setup-create-user/setup-user5.png
-    :width: 600
-
-6. Click on :guilabel:`Add new attribute` which should show a pull-down menu and then select :guilabel:`memberUid`. Enter the `memberUid` of the user you just created, and then update the object.
-
-  .. image:: /img/setup-create-user/setup-user6.png
-    :width: 600
-
-  .. image:: /img/setup-create-user/setup-user7.png
-    :width: 600
-
-7. Navigate to http://[IP_ADDRESS]/web-ui/login in order to access the login screen.
-
-  .. image:: /img/setup-create-user/setup-user8.png
-    :width: 600
 
   .. note::
     If you are unable to log in, you may need to take the docker stack down and bring it back up again. That can be done with the following commands below:

--- a/odkx-src/sync-endpoint-user-instructions.rst
+++ b/odkx-src/sync-endpoint-user-instructions.rst
@@ -1,0 +1,103 @@
+.. spelling::
+  ldap
+
+
+
+
+.. _sync-endpoint-ldap-users:
+
+Creating users
+"""""""""""""""""""""""""
+
+  1. Click: :guilabel:`login` on the left and login as *admin*.
+  2. Expand the tree view on the left until you see :guilabel:`ou=people`.
+  3. Click on :guilabel:`ou=people` and choose :guilabel:`Create a child entry`.
+  4. Choose the :guilabel:`Generic: User Account` template.
+  5. Fill out the form and click :guilabel:`Create Object`.
+  6. Assign users to groups with :ref:`these instructions <sync-endpoint-ldap-assign>`.
+
+
+.. _sync-endpoint-ldap-groups:
+
+Creating groups
+"""""""""""""""""""""""""
+
+  1. Click: :guilabel:`login` on the left and login as *admin*.
+  2. Expand the tree view on the left until you see :guilabel:`ou=groups`.
+  3. Click on :guilabel:`ou=default_prefix` and choose :guilabel:`Create a child entry`.
+  4. Choose the :guilabel:`Generic: Posix Group` template.
+  5. Fill out the form and click :guilabel:`Create Object`.
+
+  .. note::
+
+    The group name must start with the group prefix, in this case the group prefix is *default_prefix* so for example: *default_prefix my-new-group*
+
+  6. Assign users to groups with :ref:`these instructions <sync-endpoint-ldap-assign>`.
+
+
+
+.. _sync-endpoint-ldap-assign:
+
+Assigning users to groups
+"""""""""""""""""""""""""
+
+  1. Click: :guilabel:`login` on the right and login as *admin*.
+  2. Expand the tree view on the right until you see :guilabel:`ou=default_prefix`, then expand :guilabel:`ou=default_prefix`.
+  3. This list is all the groups under *ou=default_prefix*.
+  4. Click on the group that you want to assign users to.
+  5. A few groups are created when the LDAP server is brought up, refer to :doc:`data-permission-filters` for descriptions of these groups.
+  6. If the :guilabel:`memberUid` section is not present:
+
+      a. Choose :guilabel:`Add new attribute`.
+      b. Choose :guilabel:`memberUid` from the dropdown, then enter :guilabel:`uid` of the user you want to assign.
+      c. Click :guilabel:`Update Object` at the bottom to update.
+
+  7. If the :guilabel:`memberUid` section is present,
+
+    a. Navigate to the :guilabel:`memberUid` section.
+    b. Click modify group members to manage members.
+
+
+
+
+.. _sync-endpoint-setup-create-user:
+
+Creating a Sample User
+----------------------
+
+| 1. Start by logging into the ldap-service. Copy the login below.
+|   - login DN: :guilabel:`cn=admin,dc=example,dc=org`
+|   - password: :guilabel:`admin`
+
+    .. image:: /img/setup-create-user/setup-user1.png
+      :width: 600
+
+2. Click the :guilabel:`+` sign next to **dc=example, dc=org** to expand it. Within the unfolded menu, in the **ou=people** section, click on :guilabel:`Create a child entry` (new person).
+
+  .. image:: /img/setup-create-user/setup-user2.png
+    :width: 600
+
+3. Then, select the :guilabel:`Generic: User Account` template.
+
+  .. image:: /img/setup-create-user/setup-user3.png
+    :width: 600
+
+4. Fill out information for the new user and “create object.” Assign it to the *default_prefix_synchronize_tables* group. Will need to commit (confirm) that you want to create this entry on the next screen.
+
+  .. image:: /img/setup-create-user/setup-user4.png
+    :width: 600
+
+  We have now created the user! We just need to add the user to the respective group from the group settings.
+
+5. Click the :guilabel:`+` sign next **ou=groups** to expand it. Within the unfolded menu, in the **ou=default_prefix** section, click on :guilabel:`gidNumber=503`, which is the group ID that corresponds to *default_prefix_synchronize_tables*. Groups correspond to the access permissions available to a certain user.
+
+  .. image:: /img/setup-create-user/setup-user5.png
+    :width: 600
+
+6. Click on :guilabel:`Add new attribute` which should show a pull-down menu and then select :guilabel:`memberUid`. Enter the `memberUid` of the user you just created, and then update the object.
+
+  .. image:: /img/setup-create-user/setup-user6.png
+    :width: 600
+
+  .. image:: /img/setup-create-user/setup-user7.png
+    :width: 600

--- a/odkx-src/sync-endpoint-user-instructions.rst
+++ b/odkx-src/sync-endpoint-user-instructions.rst
@@ -1,5 +1,10 @@
 .. spelling::
   ldap
+  phpLDAPadmin
+  readonly
+  dns
+  letsencrypt
+  subdomain
 
 
 
@@ -100,4 +105,9 @@ Creating a Sample User
     :width: 600
 
   .. image:: /img/setup-create-user/setup-user7.png
+    :width: 600
+    
+7. Navigate to http://[IP_ADDRESS]/web-ui/login in order to access the login screen.
+
+  .. image:: /img/setup-create-user/setup-user8.png
     :width: 600

--- a/odkx-src/sync-endpoint-user-instructions.rst
+++ b/odkx-src/sync-endpoint-user-instructions.rst
@@ -61,53 +61,50 @@ Assigning users to groups
 
     a. Navigate to the :guilabel:`memberUid` section.
     b. Click modify group members to manage members.
-
-
-
-
+    
 .. _sync-endpoint-setup-create-user:
 
 Creating a Sample User
-"""""""""""""""""""""""""
+----------------------
 
   | 1. Start by logging into the ldap-service. Copy the login below.
   |   - login DN: :guilabel:`cn=admin,dc=example,dc=org`
   |   - password: :guilabel:`admin`
 
-  .. image:: /img/setup-create-user/setup-user1.png
-    :width: 600
+      .. image:: /img/setup-create-user/setup-user1.png
+        :width: 600
 
   2. Click the :guilabel:`+` sign next to **dc=example, dc=org** to expand it. Within the unfolded menu, in the **ou=people** section, click on :guilabel:`Create a child entry` (new person).
 
-  .. image:: /img/setup-create-user/setup-user2.png
-    :width: 600
+    .. image:: /img/setup-create-user/setup-user2.png
+      :width: 600
 
   3. Then, select the :guilabel:`Generic: User Account` template.
 
-  .. image:: /img/setup-create-user/setup-user3.png
-    :width: 600
+    .. image:: /img/setup-create-user/setup-user3.png
+      :width: 600
 
   4. Fill out information for the new user and “create object.” Assign it to the *default_prefix_synchronize_tables* group. Will need to commit (confirm) that you want to create this entry on the next screen.
 
-  .. image:: /img/setup-create-user/setup-user4.png
-    :width: 600
+    .. image:: /img/setup-create-user/setup-user4.png
+      :width: 600
 
-  We have now created the user! We just need to add the user to the respective group from the group settings.
+    We have now created the user! We just need to add the user to the respective group from the group settings.
 
   5. Click the :guilabel:`+` sign next **ou=groups** to expand it. Within the unfolded menu, in the **ou=default_prefix** section, click on :guilabel:`gidNumber=503`, which is the group ID that corresponds to *default_prefix_synchronize_tables*. Groups correspond to the access permissions available to a certain user.
 
-  .. image:: /img/setup-create-user/setup-user5.png
-    :width: 600
+    .. image:: /img/setup-create-user/setup-user5.png
+      :width: 600
 
   6. Click on :guilabel:`Add new attribute` which should show a pull-down menu and then select :guilabel:`memberUid`. Enter the `memberUid` of the user you just created, and then update the object.
 
-  .. image:: /img/setup-create-user/setup-user6.png
-    :width: 600
+    .. image:: /img/setup-create-user/setup-user6.png
+      :width: 600
 
-  .. image:: /img/setup-create-user/setup-user7.png
-    :width: 600
-    
+    .. image:: /img/setup-create-user/setup-user7.png
+      :width: 600
+
   7. Navigate to http://[IP_ADDRESS]/web-ui/login in order to access the login screen.
 
-  .. image:: /img/setup-create-user/setup-user8.png
-    :width: 600
+    .. image:: /img/setup-create-user/setup-user8.png
+      :width: 600

--- a/odkx-src/sync-endpoint-user-instructions.rst
+++ b/odkx-src/sync-endpoint-user-instructions.rst
@@ -68,38 +68,38 @@ Assigning users to groups
 .. _sync-endpoint-setup-create-user:
 
 Creating a Sample User
-----------------------
+"""""""""""""""""""""""""
 
-| 1. Start by logging into the ldap-service. Copy the login below.
-|   - login DN: :guilabel:`cn=admin,dc=example,dc=org`
-|   - password: :guilabel:`admin`
+  | 1. Start by logging into the ldap-service. Copy the login below.
+  |   - login DN: :guilabel:`cn=admin,dc=example,dc=org`
+  |   - password: :guilabel:`admin`
 
-    .. image:: /img/setup-create-user/setup-user1.png
-      :width: 600
+  .. image:: /img/setup-create-user/setup-user1.png
+    :width: 600
 
-2. Click the :guilabel:`+` sign next to **dc=example, dc=org** to expand it. Within the unfolded menu, in the **ou=people** section, click on :guilabel:`Create a child entry` (new person).
+  2. Click the :guilabel:`+` sign next to **dc=example, dc=org** to expand it. Within the unfolded menu, in the **ou=people** section, click on :guilabel:`Create a child entry` (new person).
 
   .. image:: /img/setup-create-user/setup-user2.png
     :width: 600
 
-3. Then, select the :guilabel:`Generic: User Account` template.
+  3. Then, select the :guilabel:`Generic: User Account` template.
 
   .. image:: /img/setup-create-user/setup-user3.png
     :width: 600
 
-4. Fill out information for the new user and “create object.” Assign it to the *default_prefix_synchronize_tables* group. Will need to commit (confirm) that you want to create this entry on the next screen.
+  4. Fill out information for the new user and “create object.” Assign it to the *default_prefix_synchronize_tables* group. Will need to commit (confirm) that you want to create this entry on the next screen.
 
   .. image:: /img/setup-create-user/setup-user4.png
     :width: 600
 
   We have now created the user! We just need to add the user to the respective group from the group settings.
 
-5. Click the :guilabel:`+` sign next **ou=groups** to expand it. Within the unfolded menu, in the **ou=default_prefix** section, click on :guilabel:`gidNumber=503`, which is the group ID that corresponds to *default_prefix_synchronize_tables*. Groups correspond to the access permissions available to a certain user.
+  5. Click the :guilabel:`+` sign next **ou=groups** to expand it. Within the unfolded menu, in the **ou=default_prefix** section, click on :guilabel:`gidNumber=503`, which is the group ID that corresponds to *default_prefix_synchronize_tables*. Groups correspond to the access permissions available to a certain user.
 
   .. image:: /img/setup-create-user/setup-user5.png
     :width: 600
 
-6. Click on :guilabel:`Add new attribute` which should show a pull-down menu and then select :guilabel:`memberUid`. Enter the `memberUid` of the user you just created, and then update the object.
+  6. Click on :guilabel:`Add new attribute` which should show a pull-down menu and then select :guilabel:`memberUid`. Enter the `memberUid` of the user you just created, and then update the object.
 
   .. image:: /img/setup-create-user/setup-user6.png
     :width: 600
@@ -107,7 +107,7 @@ Creating a Sample User
   .. image:: /img/setup-create-user/setup-user7.png
     :width: 600
     
-7. Navigate to http://[IP_ADDRESS]/web-ui/login in order to access the login screen.
+  7. Navigate to http://[IP_ADDRESS]/web-ui/login in order to access the login screen.
 
   .. image:: /img/setup-create-user/setup-user8.png
     :width: 600

--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -96,55 +96,6 @@ The following guides assume that you're using :program:`phpLDAPadmin`. In order 
 
 Recommended :ref:`Creating a Sample User <sync-endpoint-setup-create-user>` tutorial with images.
 
-.. _sync-endpoint-ldap-users:
-
-Creating users
-"""""""""""""""""""""""""
-
-  1. Click: :guilabel:`login` on the left and login as *admin*.
-  2. Expand the tree view on the left until you see :guilabel:`ou=people`.
-  3. Click on :guilabel:`ou=people` and choose :guilabel:`Create a child entry`.
-  4. Choose the :guilabel:`Generic: User Account` template.
-  5. Fill out the form and click :guilabel:`Create Object`.
-  6. Assign users to groups with :ref:`these instructions <sync-endpoint-ldap-assign>`.
-
-.. _sync-endpoint-ldap-groups:
-
-Creating groups
-"""""""""""""""""""""""""
-
-  1. Click: :guilabel:`login` on the left and login as *admin*.
-  2. Expand the tree view on the left until you see :guilabel:`ou=groups`.
-  3. Click on :guilabel:`ou=default_prefix` and choose :guilabel:`Create a child entry`.
-  4. Choose the :guilabel:`Generic: Posix Group` template.
-  5. Fill out the form and click :guilabel:`Create Object`.
-
-  .. note::
-
-    The group name must start with the group prefix, in this case the group prefix is *default_prefix* so for example: *default_prefix my-new-group*
-
-  6. Assign users to groups with :ref:`these instructions <sync-endpoint-ldap-assign>`.
-
-.. _sync-endpoint-ldap-assign:
-
-Assigning users to groups
-"""""""""""""""""""""""""
-
-  1. Click: :guilabel:`login` on the right and login as *admin*.
-  2. Expand the tree view on the right until you see :guilabel:`ou=default_prefix`, then expand :guilabel:`ou=default_prefix`.
-  3. This list is all the groups under *ou=default_prefix*.
-  4. Click on the group that you want to assign users to.
-  5. A few groups are created when the LDAP server is brought up, refer to :doc:`data-permission-filters` for descriptions of these groups.
-  6. If the :guilabel:`memberUid` section is not present:
-
-      a. Choose :guilabel:`Add new attribute`.
-      b. Choose :guilabel:`memberUid` from the dropdown, then enter :guilabel:`uid` of the user you want to assign.
-      c. Click :guilabel:`Update Object` at the bottom to update.
-
-  7. If the :guilabel:`memberUid` section is present,
-
-    a. Navigate to the :guilabel:`memberUid` section.
-    b. Click modify group members to manage members.
 
 .. _sync-endpoint-advanced:
 


### PR DESCRIPTION
<!-- If this PR is related to an open issue -->

addresses odk-x/tool-suite-X#263


#### What is included in this PR?

Created a new documentation file to consolidate sync-endpoint user instructions into its own section under sync endpoint.

Moved the instruction for creating users, creating groups, assigning groups, and creating sample users from https://docs.odk-x.org/sync-endpoint/#creating-groups and https://docs.odk-x.org/sync-endpoint-cloud-setup/#creating-a-sample-user  to the new file.

