### PR TITLE
#279 - Add deprecated and currently not supported section in docs

### DIFF
--- a/odkx-src/aggregate-tables-extension.rst
+++ b/odkx-src/aggregate-tables-extension.rst
@@ -3,13 +3,13 @@ ODK Aggregate Tables Extension
 .. warning::
     Aggregate is deprecated and no longer supported.
 
-.. _aggregate-tables-extension-intro:
+.. _aggregate-tables-extension-introduction:
 
 :dfn:`ODK Aggregate Tables Extensions` enable the ODK-X tools to share data via bi-directional synchronization with a central ODK Aggregate server. However, this approach is no longer supported, please migrate to :doc:`sync-endpoint`.
 
 The `ODK-X REST Protocol <https://docs.odk-x.org/odk-2-sync-protocol/>`_ is compatible with ODK Aggregate v1.4.15. The sync protocol has been augmented to cache the user's permissions on the device and, for super-users or administrators, to cache the full set of users and all of their permissions (so that the super-user and/or administrator can assign rows to particular individuals).
 
-.. _aggregate-tables-extension-server-setup:
+.. _aggregate-tables-extension-intro-server-setup:
 
 Server Setup
 -------------------
@@ -27,7 +27,7 @@ First you’ll have to install ODK Aggregate v1.4.15 to a server.
   #. Select at least one user to be the administrator and grant them :guilabel:`Administer Tables` permissions. This user will have the ability to :guilabel:`Reset App Server` from the Android device and add or remove tables and configuration files on the server. This is the equivalent of the Form Manager permissions in ODK deployments.
   #. Click :guilabel:`Save Changes`. These changes will not take effect until you do!
 
-.. _aggregate-tables-extension-changing-appname:
+.. _aggregate-tables-extension-changing-application-name:
 
 Changing the AppName
 -----------------------

--- a/odkx-src/cloud-endpoints-intro.rst
+++ b/odkx-src/cloud-endpoints-intro.rst
@@ -16,4 +16,3 @@ Learn more about ODK-X Cloud Endpoints
 -------------------------------------------
 
 - :doc:`sync-endpoint`
-- :doc:`aggregate-tables-extension`

--- a/odkx-src/index.rst
+++ b/odkx-src/index.rst
@@ -200,10 +200,6 @@ The :doc:`tables-sample-app` walks you through the process of using a basic tabl
   :caption: Currently Not Supported
 
   scan-intro
-  scan-install
-  scan-using
-  scan-managing
-  scan-data
 
 .. toctree::
   :maxdepth: 2

--- a/odkx-src/index.rst
+++ b/odkx-src/index.rst
@@ -163,7 +163,6 @@ The :doc:`tables-sample-app` walks you through the process of using a basic tabl
   sync-endpoint-cloud-setup
   sync-endpoint-manual-setup
   sync-endpoint-user-instructions.rst
-  aggregate-tables-extension
 
 .. toctree::
   :maxdepth: 2
@@ -171,17 +170,6 @@ The :doc:`tables-sample-app` walks you through the process of using a basic tabl
   :caption: Suitcase
 
   suitcase-intro
-
-.. toctree::
-  :maxdepth: 2
-  :hidden:
-  :caption: Scan
-
-  scan-intro
-  scan-install
-  scan-using
-  scan-managing
-  scan-data
 
 .. toctree::
   :maxdepth: 2
@@ -205,6 +193,24 @@ The :doc:`tables-sample-app` walks you through the process of using a basic tabl
   :caption: Contributing
 
   contributing
+
+.. toctree::
+  :maxdepth: 2
+  :hidden:
+  :caption: Currently Not Supported
+
+  scan-intro
+  scan-install
+  scan-using
+  scan-managing
+  scan-data
+
+.. toctree::
+  :maxdepth: 2
+  :hidden:
+  :caption: Deprecated
+
+  aggregate-tables-extension
 
 .. toctree::
   :maxdepth: 2

--- a/odkx-src/index.rst
+++ b/odkx-src/index.rst
@@ -151,7 +151,6 @@ The :doc:`tables-sample-app` walks you through the process of using a basic tabl
   xlsx-converter-intro
   tables-web-pages
   injected-interfaces
-  scan-form-designer-intro
 
 .. toctree::
   :maxdepth: 2
@@ -200,6 +199,7 @@ The :doc:`tables-sample-app` walks you through the process of using a basic tabl
   :caption: Currently Not Supported
 
   scan-intro
+  scan-form-designer-intro
 
 .. toctree::
   :maxdepth: 2

--- a/odkx-src/scan-data.rst
+++ b/odkx-src/scan-data.rst
@@ -1,11 +1,11 @@
 Managing ODK-X Scan's Data
 ============================
 
-.. _odkx-scan-data:
+.. _odk-x-scan-data:
 
 ODK-X Scan shares a database with the rest of the ODK-X tools, and the data can be accessed using the normal means through the :doc:`cloud-endpoints-intro` and :doc:`suitcase-intro`. However, Scan adds extra columns to store snippets of each data field's original image, the image file type, and the data value predicted by Scan.
 
-.. _odkx-scan-using-suitcase:
+.. _odk-x-scan-using-suitcase:
 
 Suitcase Formatting
 ------------------------------------------

--- a/odkx-src/scan-data.rst
+++ b/odkx-src/scan-data.rst
@@ -1,11 +1,11 @@
 Managing ODK-X Scan's Data
 ============================
 
-.. _scan-data:
+.. _odkx-scan-data:
 
 ODK-X Scan shares a database with the rest of the ODK-X tools, and the data can be accessed using the normal means through the :doc:`cloud-endpoints-intro` and :doc:`suitcase-intro`. However, Scan adds extra columns to store snippets of each data field's original image, the image file type, and the data value predicted by Scan.
 
-.. _scan-using-suitcase:
+.. _odkx-scan-using-suitcase:
 
 Suitcase Formatting
 ------------------------------------------

--- a/odkx-src/scan-install.rst
+++ b/odkx-src/scan-install.rst
@@ -1,7 +1,7 @@
 Installing ODK-X Scan
 =======================
 
-.. _scan-prereqs:
+.. _odkx-scan-prereqs:
 
 Prerequisites
 -------------------
@@ -16,7 +16,7 @@ As well as the following third party apps:
 
   - `OI File Manager <https://github.com/openintents/filemanager/releases>`_
 
-.. _scan-install:
+.. _odkx-scan-install:
 
 Installing Scan
 -----------------------

--- a/odkx-src/scan-install.rst
+++ b/odkx-src/scan-install.rst
@@ -1,7 +1,7 @@
 Installing ODK-X Scan
 =======================
 
-.. _odkx-scan-prereqs:
+.. _odk-x-scan-prereqs:
 
 Prerequisites
 -------------------
@@ -16,7 +16,7 @@ As well as the following third party apps:
 
   - `OI File Manager <https://github.com/openintents/filemanager/releases>`_
 
-.. _odkx-scan-install:
+.. _odk-x-scan-install:
 
 Installing Scan
 -----------------------

--- a/odkx-src/scan-intro.rst
+++ b/odkx-src/scan-intro.rst
@@ -1,7 +1,7 @@
 ODK-X Scan
 ===============
 
-.. _odkx-scan-intro:
+.. _odk-x-scan-intro:
 
 .. warning::
 
@@ -17,14 +17,17 @@ ODK-X Scan
 .. image:: /img/scan-intro/scan-process.*
   :alt: The ODK-X Scan Process
 
-.. _odkx-scan-intro-learn-more:
+.. _odk-x-scan-intro-learn-more:
 
 Learn more about ODK-X Scan
 ----------------------------
+.. toctree::
+  :maxdepth: 2
 
-- :doc:`scan-install`
-- :doc:`scan-using`
-- :doc:`scan-managing`
-- :doc:`scan-data`
+  scan-install
+  scan-using
+  scan-managing
+  scan-data
+
   
   

--- a/odkx-src/scan-intro.rst
+++ b/odkx-src/scan-intro.rst
@@ -1,7 +1,7 @@
 ODK-X Scan
-============
+===============
 
-.. _scan-intro:
+.. _odkx-scan-intro:
 
 .. warning::
 
@@ -17,7 +17,7 @@ ODK-X Scan
 .. image:: /img/scan-intro/scan-process.*
   :alt: The ODK-X Scan Process
 
-.. _scan-intro-learn-more:
+.. _odkx-scan-intro-learn-more:
 
 Learn more about ODK-X Scan
 ----------------------------

--- a/odkx-src/scan-managing.rst
+++ b/odkx-src/scan-managing.rst
@@ -1,11 +1,11 @@
 Managing ODK-X Scan
 ======================
 
-.. _odkx-scan-managing:
+.. _odk-x-scan-managing:
 
 .. contents:: :local:
 
-.. _odkx-scan-architect-prereqs:
+.. _odk-x-scan-architect-prereqs:
 
 Prerequisites
 ---------------------
@@ -24,7 +24,7 @@ As well as the third party apps:
 
 If you have not installed Scan already, follow our guide for :doc:`scan-install`
 
-.. _odkx-scan-transferring-template:
+.. _odk-x-scan-transferring-template:
 
 Transferring a Form Template to the App
 ------------------------------------------

--- a/odkx-src/scan-managing.rst
+++ b/odkx-src/scan-managing.rst
@@ -1,11 +1,11 @@
 Managing ODK-X Scan
 ======================
 
-.. _scan-managing:
+.. _odkx-scan-managing:
 
 .. contents:: :local:
 
-.. _scan-architect-prereqs:
+.. _odkx-scan-architect-prereqs:
 
 Prerequisites
 ---------------------
@@ -24,7 +24,7 @@ As well as the third party apps:
 
 If you have not installed Scan already, follow our guide for :doc:`scan-install`
 
-.. _scan-transferring-template:
+.. _odkx-scan-transferring-template:
 
 Transferring a Form Template to the App
 ------------------------------------------

--- a/odkx-src/scan-using.rst
+++ b/odkx-src/scan-using.rst
@@ -4,16 +4,16 @@
 Using ODK-X Scan
 ====================
 
-.. _odkx-scan-using:
+.. _odk-x-scan-using:
 
 .. contents:: :local:
 
-.. _odkx-scan-using-scanning-form:
+.. _odk-x-scan-using-scanning-form:
 
 Scanning a Form
 ------------------------------------------
 
-.. _odkx-scan-using-scanning-form-prior:
+.. _odk-x-scan-using-scanning-form-prior:
 
 Prior to scanning
 ~~~~~~~~~~~~~~~~~~~
@@ -26,7 +26,7 @@ Open the Scan app, and be sure that the template you want to use this session is
   :alt: Example of Scan template selection
   :class: device-screen-vertical
 
-.. _odkx-scan-using-scanning-form-scanning:
+.. _odk-x-scan-using-scanning-form-scanning:
 
 Scanning the form
 ~~~~~~~~~~~~~~~~~~~
@@ -62,12 +62,12 @@ Scanning the form
   .. image:: /img/scan-using/scan-stand.*
     :alt: Custom build stand for improved Scan accuracy
 
-.. _odkx-scan-using-survey:
+.. _odk-x-scan-using-survey:
 
 Survey: View, Verify, & Edit Data
 ------------------------------------------
 
-.. _odkx-scan-using-survey-review:
+.. _odk-x-scan-using-survey-review:
 
 Reviewing Your Data
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -78,7 +78,7 @@ You'll be taken to Survey after pressing :guilabel:`Transcribe` on a scan. There
   :alt: View of a scanned form in ODK-X Survey
   :class: device-screen-vertical
 
-.. _odkx-scan-using-survey-verify:
+.. _odk-x-scan-using-survey-verify:
 
 To verify and edit any of the data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,7 +109,7 @@ Navigate to the next section to validate and edit either by:
     :alt: View of a scanned text field in ODK-X Survey
     :class: device-screen-vertical
 
-.. _odkx-scan-using-survey-finalize:
+.. _odk-x-scan-using-survey-finalize:
 
 Saving and Finalizing Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -124,7 +124,7 @@ Once you've verified all the fields, select :menuselection:`Form Name --> Finali
   :alt: Finalizing changes in ODK-X Survey
   :class: device-screen-vertical
 
-.. _odkx-scan-using-tables:
+.. _odk-x-scan-using-tables:
 
 Your Data in Tables
 ------------------------------------------

--- a/odkx-src/scan-using.rst
+++ b/odkx-src/scan-using.rst
@@ -4,16 +4,16 @@
 Using ODK-X Scan
 ====================
 
-.. _scan-using:
+.. _odkx-scan-using:
 
 .. contents:: :local:
 
-.. _scan-using-scanning-form:
+.. _odkx-scan-using-scanning-form:
 
 Scanning a Form
 ------------------------------------------
 
-.. _scan-using-scanning-form-prior:
+.. _odkx-scan-using-scanning-form-prior:
 
 Prior to scanning
 ~~~~~~~~~~~~~~~~~~~
@@ -26,7 +26,7 @@ Open the Scan app, and be sure that the template you want to use this session is
   :alt: Example of Scan template selection
   :class: device-screen-vertical
 
-.. _scan-using-scanning-form-scanning:
+.. _odkx-scan-using-scanning-form-scanning:
 
 Scanning the form
 ~~~~~~~~~~~~~~~~~~~
@@ -62,12 +62,12 @@ Scanning the form
   .. image:: /img/scan-using/scan-stand.*
     :alt: Custom build stand for improved Scan accuracy
 
-.. _scan-using-survey:
+.. _odkx-scan-using-survey:
 
 Survey: View, Verify, & Edit Data
 ------------------------------------------
 
-.. _scan-using-survey-review:
+.. _odkx-scan-using-survey-review:
 
 Reviewing Your Data
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -78,7 +78,7 @@ You'll be taken to Survey after pressing :guilabel:`Transcribe` on a scan. There
   :alt: View of a scanned form in ODK-X Survey
   :class: device-screen-vertical
 
-.. _scan-using-survey-verify:
+.. _odkx-scan-using-survey-verify:
 
 To verify and edit any of the data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,7 +109,7 @@ Navigate to the next section to validate and edit either by:
     :alt: View of a scanned text field in ODK-X Survey
     :class: device-screen-vertical
 
-.. _scan-using-survey-finalize:
+.. _odkx-scan-using-survey-finalize:
 
 Saving and Finalizing Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -124,7 +124,7 @@ Once you've verified all the fields, select :menuselection:`Form Name --> Finali
   :alt: Finalizing changes in ODK-X Survey
   :class: device-screen-vertical
 
-.. _scan-using-tables:
+.. _odkx-scan-using-tables:
 
 Your Data in Tables
 ------------------------------------------


### PR DESCRIPTION
<!-- If this PR is related to an open issue -->
closes odk-x/tool-suite-X#279
<!-- OR -->
<!-- addresses odk-x/tool-suite-X#279 -->


#### What is included in this PR?
1. Adding Deprecated and Currently Not Supported section to the Documentation TOC tree and 
2. Move the Scan section to Currently Not Supported and Aggregate Tables extension to Deprecated

<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?
None that I could think of.

#### What is left to be done in the addressed issue?
I need feedback on the problem stated below.

#### What problems did you encounter?
I added the Deprecated and Currently Not supported to the docs toctree, moved the page file names for scan and aggregate tables extension in the index.rst file and served it locally on my PC.

When it’s on the home page (index), it’s fine and the newly added section show up. When I click the aggregate tables link (under Deprecated), it reverts back to the cloud endpoints section. I edited the section labels for the pages and it didn’t revert but when I click any other link from the Docs sidebar TOC, the new sections don’t show up.