### PR TITLE
Add signature key to build scripts section in docs

### DIFF
--- a/odkx-src/build-scripts.rst
+++ b/odkx-src/build-scripts.rst
@@ -69,12 +69,13 @@ If you are on :program:`Windows` use :file:`gradlew.bat` instead.
 
 .. warning::
 
-  The Android tools have a release signature key unique to the ODK-X applications. Communication between the applications is secured by this key and can only happen when the application keys match. This ensures that the information passing between the applications cannot be intercepted by another application.
-  You can find more information on Android app signing `here <https://developer.android.com/studio/publish/app-signing>`_.
+  The Android tools have a release signing key unique to the ODK-X applications. This key provides authentication for a form of communication between the application called IPC calls. Communication between the applications can only happen when the application signing keys are a match. 
+  
+  You can find more information on Android app signing `here <https://developer.android.com/studio/publish/app-signing>`_. Additionally, the key is tied to the Google Maps API key and checked by the Google Maps library.
   
   When you compile the Android tools locally, they get assigned a new key called a default debug key. Your compiled application will only be able to communicate with another locally compiled application because their default debug keys are the same.
   
-  It is important to know this because your locally compiled application cannot communicate with other ODK-X Android apps unless the apps are locally compiled.
+  It is important to know this because your locally compiled application cannot communicate with other ODK-X Android apps unless the apps are locally compiled. 
 
 .. _build-scripts-flavors:
 

--- a/odkx-src/build-scripts.rst
+++ b/odkx-src/build-scripts.rst
@@ -69,11 +69,12 @@ If you are on :program:`Windows` use :file:`gradlew.bat` instead.
 
 .. warning::
 
-  The Android tools have a release signature key unique to the ODK-X applications, communication between the applications are secured by this key and can happen when the application keys match. This ensures that the information between the applications cannot be intercepted by another application. 
+  The Android tools have a release signature key unique to the ODK-X applications. Communication between the applications is secured by this key and can only happen when the application keys match. This ensures that the information passing between the applications cannot be intercepted by another application.
+  You can find more information on Android app signing `here <https://developer.android.com/studio/publish/app-signing>`_.
   
-  When you compile the Android tools locally, it gets assigned a new key called a default debug key. Your compiled application will only be able to communicate with another locally compiled application because their default debug keys are the same.
+  When you compile the Android tools locally, they get assigned a new key called a default debug key. Your compiled application will only be able to communicate with another locally compiled application because their default debug keys are the same.
   
-  It is important to know this because your locally compiled application cannot communicate with ODK-X Services unless ODK-X Services is locally compiled.
+  It is important to know this because your locally compiled application cannot communicate with other ODK-X Android apps unless the apps are locally compiled.
 
 .. _build-scripts-flavors:
 

--- a/odkx-src/build-scripts.rst
+++ b/odkx-src/build-scripts.rst
@@ -67,6 +67,14 @@ If you are on :program:`Windows` use :file:`gradlew.bat` instead.
 
   If you are building with Android Studio, you will need to select the correct build variant. This is important when you don't have androidlibrary or androidcommon in your :ref:`build-scripts-directory-structure`. These are discussed more in the :ref:`next section <build-scripts-flavors>`.
 
+.. warning::
+
+  The Android tools have a release signature key unique to the ODK-X applications, communication between the applications are secured by this key and can happen when the application keys match. This ensures that the information between the applications cannot be intercepted by another application. 
+  
+  When you compile the Android tools locally, it gets assigned a new key called a default debug key. Your compiled application will only be able to communicate with another locally compiled application because their default debug keys are the same.
+  
+  It is important to know this because your locally compiled application cannot communicate with ODK-X Services unless ODK-X Services is locally compiled.
+
 .. _build-scripts-flavors:
 
 Flavors


### PR DESCRIPTION
<!-- If this PR is related to an open issue -->

<!-- OR -->
addresses odk-x/tool-suite-X#284


#### What is included in this PR?
1. Information on signature keys for building the Android Tools 


<!-- Answer any that apply and delete the others. -->


#### What is left to be done in the addressed issue?
Add this information to the android tools GitHub README


