### PR TITLE
fixed typos- two periods after word color, incorrect script to activa…

### DIFF
--- a/odkx-src/docs-tech-guide.rst
+++ b/odkx-src/docs-tech-guide.rst
@@ -616,7 +616,7 @@ on any computer.
 
             .. code:: console
 
-               /odk/ > .\odkxenv\Scripts\activate
+               /odk/ > .\odkenv\Scripts\activate
                (odkenv) /odk/ >
 
       The ``(odkenv)`` before the prompt shows that the virtual environment is active.

--- a/odkx-src/getting-started-2-architect.rst
+++ b/odkx-src/getting-started-2-architect.rst
@@ -56,7 +56,7 @@ Now, open a file browser and navigate to the directory where you downloaded the 
 
 Navigate within that directory to :file:`app/config/tables/exampleForm/forms/exampleForm`. Open the :file:`exampleForm.xlsx` file in :program:`Excel` (or :program:`OpenOffice`). This is the form definition used by ODK-X Survey.
 
-We will be adding a question to ask the user to enter their favorite color.. For this example, we will be collecting a text response. A more useful modification might restrict the user to a set of choices (red, orange, yellow, green, and so on).
+We will be adding a question to ask the user to enter their favorite color. For this example, we will be collecting a text response. A more useful modification might restrict the user to a set of choices (red, orange, yellow, green, and so on).
 
 On the survey worksheet, insert a row below the first row. Edit the values of the created row in each of the columns shown below, and leave the cells under all other columns in this row empty.
 


### PR DESCRIPTION
…te venv in powershell

addresses odk-x/tool-suite-X#207


#### What is included in this PR?

I made a small typo fix to getting-started-2-architect. (The text-sentence had two periods)
And the docs-tech-guide has an incorrect script to activate the virtual environment (it was odkx/..., should be odk/...)

<!-- Answer any that apply and delete the others. -->

#### What problems did you encounter?
I had a some problems with installing and running sphinx on my Mac. When I ran make odkx-check I got this error:

tmpx-src/conf.py:100: RemovedInSphinx40Warning: The alias 'sphinx.builders.html.DirectoryHTMLBuilder' is deprecated, use 'sphinx.builders.dirhtml.DirectoryHTMLBuilder' instead. Check CHANGES for Sphinx API modifications.
  from sphinx.builders.html import DirectoryHTMLBuilder

Extension error:
Could not import extension sphinxcontrib.spelling (exception: The 'enchant' C library was not found and maybe needs to be installed.
See  https://pyenchant.github.io/pyenchant/install.html
for details
)
make: *** [odkx] Error 2

I tried installing the library on the website in the virtual environment but it didn't fix the issue.

Because my changes were small, I went ahead and pushed anyway. 