### PR TITLE
Remove OI File Manager requirement from documentation

### DIFF
--- a/odkx-src/basics-install.rst
+++ b/odkx-src/basics-install.rst
@@ -16,10 +16,6 @@ If you are working on a Windows/Mac/Linux machine, you can use `Android Studio <
 
   Please note that ODK-X Services version 2.1.7 doesn't work on Android 11. You will need Android 10 with an API level of less than 30 for version 2.1.7.
 
-Before installing any of the ODK-X tools, you will need the following third-party app:
-
-  - `OI File Manager <https://github.com/openintents/filemanager/releases>`_
-
 Required
 ~~~~~~~~~~~~~~~
 

--- a/odkx-src/basics-install.rst
+++ b/odkx-src/basics-install.rst
@@ -16,6 +16,10 @@ If you are working on a Windows/Mac/Linux machine, you can use `Android Studio <
 
   Please note that ODK-X Services version 2.1.7 doesn't work on Android 11. You will need Android 10 with an API level of less than 30 for version 2.1.7.
 
+Before installing any of the ODK-X tools, you will need the following third-party app:
+
+  - `Files by Google <https://play.google.com/store/apps/details?id=com.google.android.apps.nbu.files&hl=en&gl=US>`_
+
 Required
 ~~~~~~~~~~~~~~~
 

--- a/odkx-src/getting-started-2-architect.rst
+++ b/odkx-src/getting-started-2-architect.rst
@@ -106,7 +106,7 @@ Preparing the Device
 
 If you followed along with the :doc:`survey-sample-app`, you should already have all the necessary tools installed on your device. If not, follow the :doc:`basics-install` instructions to install ODK-X Services, ODK-X Survey, and ODK-X Tables.
 
-First, open a file manager on the device. Delete the whole :guilabel:`opendatakit` folder by clicking the folder and holding it until it becomes highlighted in blue. Then press the delete icon, and click :guilabel:`OK` in the resulting window.
+First, open the :guilabel:`Files by Google` app on the device. Delete the whole :guilabel:`opendatakit` folder by clicking the folder and holding it until it becomes highlighted in blue. Then press the delete icon, and click :guilabel:`OK` in the resulting window.
 
 .. image:: /img/getting-started-2/file-manager-delete-folder.*
   :alt: Delete opendatakit folder in OI File Manager

--- a/odkx-src/getting-started-2-architect.rst
+++ b/odkx-src/getting-started-2-architect.rst
@@ -106,7 +106,7 @@ Preparing the Device
 
 If you followed along with the :doc:`survey-sample-app`, you should already have all the necessary tools installed on your device. If not, follow the :doc:`basics-install` instructions to install ODK-X Services, ODK-X Survey, and ODK-X Tables.
 
-First, open the :guilabel:`OI File Manager` on the device. Delete the whole :guilabel:`opendatakit` folder by clicking the folder and holding it until it becomes highlighted in blue. Then press the delete icon, and click :guilabel:`OK` in the resulting window.
+First, open a file manager on the device. Delete the whole :guilabel:`opendatakit` folder by clicking the folder and holding it until it becomes highlighted in blue. Then press the delete icon, and click :guilabel:`OK` in the resulting window.
 
 .. image:: /img/getting-started-2/file-manager-delete-folder.*
   :alt: Delete opendatakit folder in OI File Manager

--- a/odkx-src/scan-install.rst
+++ b/odkx-src/scan-install.rst
@@ -12,6 +12,8 @@ Before installing ODK-X Scan, you will need the following ODK-X Tools:
   - :doc:`survey-using`
   - :doc:`tables-using`
 
+As well as the `Files by Google <https://play.google.com/store/apps/details?id=com.google.android.apps.nbu.files&hl=en&gl=US>`_ app.
+
 .. _odk-x-scan-install:
 
 Installing Scan

--- a/odkx-src/scan-install.rst
+++ b/odkx-src/scan-install.rst
@@ -12,10 +12,6 @@ Before installing ODK-X Scan, you will need the following ODK-X Tools:
   - :doc:`survey-using`
   - :doc:`tables-using`
 
-As well as the following third-party apps:
-
-  - `OI File Manager <https://github.com/openintents/filemanager/releases>`_
-
 .. _odk-x-scan-install:
 
 Installing Scan

--- a/odkx-src/scan-managing.rst
+++ b/odkx-src/scan-managing.rst
@@ -18,6 +18,8 @@ To create an Data Management Application that uses ODK-X Scan, you will need the
   - :doc:`app-designer-intro`
   - :doc:`cloud-endpoints-intro`
 
+As well as the `Files by Google <https://play.google.com/store/apps/details?id=com.google.android.apps.nbu.files&hl=en&gl=US>`_ app.
+
 If you have not installed Scan already, follow our guide for :doc:`scan-install`
 
 .. _odk-x-scan-transferring-template:

--- a/odkx-src/scan-managing.rst
+++ b/odkx-src/scan-managing.rst
@@ -18,10 +18,6 @@ To create an Data Management Application that uses ODK-X Scan, you will need the
   - :doc:`app-designer-intro`
   - :doc:`cloud-endpoints-intro`
 
-As well as the third-party apps:
-
-- `OI File Manager <https://play.google.com/store/apps/details?id=org.openintents.filemanager>`_
-
 If you have not installed Scan already, follow our guide for :doc:`scan-install`
 
 .. _odk-x-scan-transferring-template:

--- a/odkx-src/services-managing.rst
+++ b/odkx-src/services-managing.rst
@@ -298,7 +298,7 @@ When you have finished configuring the administrator settings, back out of the m
 Resetting Configuration
 ------------------------
 
-This option will clear the ODK-X cache of table and form definitions and scan the file system to refill that cache. This is automatically run after each successful sync operation to ensure that Survey and Tables display the correct information. If you have manually modified files inside of the :file:`/sdcard/opendatakit/` folder via :program:`grunt` commands, with :program:`OI File Manager`, or by some other means, you may need to use this option to refresh the cache. If you are not seeing forms or tables that you expect, this option may fix that problem.
+This option will clear the ODK-X cache of table and form definitions and scan the file system to refill that cache. This is automatically run after each successful sync operation to ensure that Survey and Tables display the correct information. If you have manually modified files inside of the :file:`/sdcard/opendatakit/` folder via :program:`grunt` commands, with a file manager, or by some other means, you may need to use this option to refresh the cache. If you are not seeing forms or tables that you expect, this option may fix that problem.
 
 .. note::
 

--- a/odkx-src/services-managing.rst
+++ b/odkx-src/services-managing.rst
@@ -298,7 +298,7 @@ When you have finished configuring the administrator settings, back out of the m
 Resetting Configuration
 ------------------------
 
-This option will clear the ODK-X cache of table and form definitions and scan the file system to refill that cache. This is automatically run after each successful sync operation to ensure that Survey and Tables display the correct information. If you have manually modified files inside of the :file:`/sdcard/opendatakit/` folder via :program:`grunt` commands, with a file manager, or by some other means, you may need to use this option to refresh the cache. If you are not seeing forms or tables that you expect, this option may fix that problem.
+This option will clear the ODK-X cache of table and form definitions and scan the file system to refill that cache. This is automatically run after each successful sync operation to ensure that Survey and Tables display the correct information. If you have manually modified files inside of the :file:`/sdcard/opendatakit/` folder via :program:`grunt` commands, with :program:`Files by Google`, or by some other means, you may need to use this option to refresh the cache. If you are not seeing forms or tables that you expect, this option may fix that problem.
 
 .. note::
 

--- a/odkx-src/survey-using.rst
+++ b/odkx-src/survey-using.rst
@@ -290,7 +290,7 @@ By default, ODK-X Survey runs under the *default* application name (as does ODK-
 
 Here we describe how to launch the ODK-X tools into an application name of your choice with the use of widget shortcuts.
 
-First, you must create an alternative application. As a contrived example, we will make an exact copy of the *default* application on the device with a new name. To do so, first load an application to the device (such as the :ref:`sample application <survey-sample-app-install>`). Then open :program:`OI File Manager`, navigate to the :file:`/sdcard/opendatakit` directory, and copy the *default* directory, renaming it *myapp*. You have now created the *myapp* application! It is isolated from and operates independently of the default application.
+First, you must create an alternative application. As a contrived example, we will make an exact copy of the *default* application on the device with a new name. To do so, first load an application to the device (such as the :ref:`sample application <survey-sample-app-install>`). Then open a file manager, navigate to the :file:`/sdcard/opendatakit` directory, and copy the *default* directory, renaming it *myapp*. You have now created the *myapp* application! It is isolated from and operates independently of the default application.
 
 To launch and use that application:
 
@@ -302,7 +302,7 @@ Android 4.x Devices
   #. Choose to view the installed applications.
   #. Select the :guilabel:`Widgets` tab at the top of that screen.
   #. Navigate through the available widgets, and select and hold the :guilabel:`ODK-X Survey Form` widget. Drag and drop it onto one of your Android launcher (home) screens.
-  #. A list of available applications and forms will appear, in the form of application name for applications, and :menuselection:`application name --> form name` for each form within an application. Pick the :menuselection:`myapp` application that you created via :program:`OI File Manager`.
+  #. A list of available applications and forms will appear, in the form of application name for applications, and :menuselection:`application name --> form name` for each form within an application. Pick the :menuselection:`myapp` application that you created.
 
 .. _survey-launching-appname-android-5:
 
@@ -312,7 +312,7 @@ Android 5.x and Higher Devices:
   #. Long press an open area of the device home screen
   #. Select the :guilabel:`Widgets` tab at the bottom of resulting screen.
   #. Navigate through the available widgets, and select and hold the :guilabel:`ODK-X Survey Form` widget. Drag and drop it onto one of your Android launcher (home) screens.
-  #. A list of available applications and forms will appear, in the form of application name for applications, and :menuselection:`application name --> form name` for each form within an application. Pick the :menuselection:`myapp` application that you created via :program:`OI File Manager`.
+  #. A list of available applications and forms will appear, in the form of application name for applications, and :menuselection:`application name --> form name` for each form within an application. Pick the :menuselection:`myapp` application that you created.
 
 .. _survey-launching-appname-try-new:
 

--- a/odkx-src/survey-using.rst
+++ b/odkx-src/survey-using.rst
@@ -290,7 +290,7 @@ By default, ODK-X Survey runs under the *default* application name (as does ODK-
 
 Here we describe how to launch the ODK-X tools into an application name of your choice with the use of widget shortcuts.
 
-First, you must create an alternative application. As a contrived example, we will make an exact copy of the *default* application on the device with a new name. To do so, first load an application to the device (such as the :ref:`sample application <survey-sample-app-install>`). Then open a file manager, navigate to the :file:`/sdcard/opendatakit` directory, and copy the *default* directory, renaming it *myapp*. You have now created the *myapp* application! It is isolated from and operates independently of the default application.
+First, you must create an alternative application. As a contrived example, we will make an exact copy of the *default* application on the device with a new name. To do so, first load an application to the device (such as the :ref:`sample application <survey-sample-app-install>`). Then open :program:`Files by Google`, navigate to the :file:`/sdcard/opendatakit` directory, and copy the *default* directory, renaming it *myapp*. You have now created the *myapp* application! It is isolated from and operates independently of the default application.
 
 To launch and use that application:
 
@@ -302,7 +302,7 @@ Android 4.x Devices
   #. Choose to view the installed applications.
   #. Select the :guilabel:`Widgets` tab at the top of that screen.
   #. Navigate through the available widgets, and select and hold the :guilabel:`ODK-X Survey Form` widget. Drag and drop it onto one of your Android launcher (home) screens.
-  #. A list of available applications and forms will appear, in the form of application name for applications, and :menuselection:`application name --> form name` for each form within an application. Pick the :menuselection:`myapp` application that you created.
+  #. A list of available applications and forms will appear, in the form of application name for applications, and :menuselection:`application name --> form name` for each form within an application. Pick the :menuselection:`myapp` application that you created via :program:`Files by Google`.
 
 .. _survey-launching-appname-android-5:
 
@@ -312,7 +312,7 @@ Android 5.x and Higher Devices:
   #. Long press an open area of the device home screen
   #. Select the :guilabel:`Widgets` tab at the bottom of resulting screen.
   #. Navigate through the available widgets, and select and hold the :guilabel:`ODK-X Survey Form` widget. Drag and drop it onto one of your Android launcher (home) screens.
-  #. A list of available applications and forms will appear, in the form of application name for applications, and :menuselection:`application name --> form name` for each form within an application. Pick the :menuselection:`myapp` application that you created.
+  #. A list of available applications and forms will appear, in the form of application name for applications, and :menuselection:`application name --> form name` for each form within an application. Pick the :menuselection:`myapp` application that you created via :program:`Files by Google`.
 
 .. _survey-launching-appname-try-new:
 

--- a/odkx-src/tables-managing.rst
+++ b/odkx-src/tables-managing.rst
@@ -55,6 +55,10 @@ The upload process is as follows:
       :alt: Table Manager Import CSV
       :class: device-screen-vertical
 
+    .. warning::
+
+      You must have installed Files by Google from the Play Store.
+
   5. Find your file, select it, and press :guilabel:`Pick file`.
   6. Press :guilabel:`Append to an Existing Table`.
 

--- a/odkx-src/tables-managing.rst
+++ b/odkx-src/tables-managing.rst
@@ -55,10 +55,6 @@ The upload process is as follows:
       :alt: Table Manager Import CSV
       :class: device-screen-vertical
 
-    .. warning::
-
-      You must have installed OI File Manager from the Play Store.
-
   5. Find your file, select it, and press :guilabel:`Pick file`.
   6. Press :guilabel:`Append to an Existing Table`.
 


### PR DESCRIPTION

closes odk-x/tool-suite-X#297

#### What is included in this PR?
Removed OI file manager from requirements as it is no longer required for the upcoming version 2.1.9 .