### PR TITLE
Update ODK-X documentation to show current minimum Android version as Version 5.0

### DIFF
--- a/odkx-src/basics-install.rst
+++ b/odkx-src/basics-install.rst
@@ -8,7 +8,7 @@ These instructions describe the steps to install the ODK-X basic tools on a tabl
 Prerequisites
 -------------------
 
-You must have an Android tablet with an operating system version 4.4 or higher.
+You must have an Android tablet with an operating system version 5.0 or higher.
 
 If you are working on a Windows/Mac/Linux machine, you can use `Android Studio <https://developer.android.com/studio>`_ to launch an Android emulator for testing purposes.
 

--- a/odkx-src/survey-using.rst
+++ b/odkx-src/survey-using.rst
@@ -12,7 +12,7 @@ ODK-X Survey
 
 .. note::
 
-  ODK-X Survey only works on Android 4.4 and newer devices.
+  ODK-X Survey only works on Android 5.0 and newer devices.
 
 .. note::
 
@@ -298,6 +298,10 @@ To launch and use that application:
 
 Android 4.x Devices
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+  Please note that ODK-X Survey version 2.1.9 does not support Android 4.x. It's minimum Android version is 5.0
 
   #. Choose to view the installed applications.
   #. Select the :guilabel:`Widgets` tab at the top of that screen.

--- a/odkx-src/tables-using.rst
+++ b/odkx-src/tables-using.rst
@@ -11,6 +11,10 @@ Tables also enables web developers to build powerful *data management applicatio
 
   ODK-X Tables only works on Android 4.2 and newer devices.
 
+.. note::
+
+  Please note that ODK-X version 2.1.9 does not support Android 4.x. It's minimum Android version is 5.0.
+
 
 We have included a sample application built on top of Tables along with a handful of data tables that showcase some of its features in :doc:`tables-sample-app`.
 


### PR DESCRIPTION

[This PR addresses odk-x/tool-suite-298#](https://github.com/odk-x/tool-suite-X/issues/298)


#### What is included in this PR?

THIS PR updates ODK-X:
1. basics-install.rst,
2. survey-using.rst, and
3. tables-using.rst
documentation to show current minimum Android version as Version 5.0
