### PR TITLE
fixing typo in docs-developer-guide.rst file

### DIFF
--- a/odkx-src/docs-developer-guide.rst
+++ b/odkx-src/docs-developer-guide.rst
@@ -336,7 +336,7 @@ in the file :file:`style-test.py`.
 Excluding built-in proselint checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To exclude an built-in proselint check,
+To exclude a built-in proselint check,
 specify the check name in the check list
 in the function :py:func:`exclude_checks`
 in the file :file:`style-test.py`.


### PR DESCRIPTION
Fixing typo in docs-developer-guide.rst file