### PR TITLE
closes odk-x/tool-suite-X#290

### DIFF
--- a/odkx-src/sync-endpoint-cloud-setup.rst
+++ b/odkx-src/sync-endpoint-cloud-setup.rst
@@ -18,7 +18,7 @@ This tutorial will help you launch ODK-X Sync Endpoint on a virtual machine host
 |   :ref:`3.	Amazon Web Services console <sync-endpoint-setup-aws>`
 
 .. note::
-  The apps require at least *2GB* of space to run, therefore, a space of more than *4GB* is recommended for server (for example - droplets on DigitalOcean).
+  The apps require at least *2GB* of space to run, therefore, at least *4GB* of space is recommended for the server (for example - a droplet on DigitalOcean).
 
 .. _sync-endpoint-setup-domain:
 


### PR DESCRIPTION
closes odk-x/tool-suite-X#290


#### What is included in this PR?
This PR includes solution to the issue 290. A recommendation of using a space of 4GB+ for the server is added to the file sync-endpoint-cloud-setup.rst. I observed that a note of using a plan of at least 4GB is already mentioned in the same file but it is provided specifically below the heading of "DigitalOcean console" cloud setup and hence I added a common note at the top.

