### PR TITLE
Document Sync-Endpoint is compatible with what DB version

### DIFF
--- a/odkx-src/sync-endpoint-manual-setup.rst
+++ b/odkx-src/sync-endpoint-manual-setup.rst
@@ -173,7 +173,7 @@ Custom database
 
   1. If you haven't followed the :ref:`common instructions <sync-endpoint-manual-setup-common>`, start with those.
   2. Remove the *db* and *db-bootstrap* sections in :file:`docker-compose.yml`.
-  3. Modify :file:`jdbc.properties`(under the directory :file:`config/sync-endpoint`) to match your database. Supported database systems are :program:`PostgreSQL`, :program:`MySQL` and :program:`Microsoft SQL Server`. Sample config for PostgreSQL can be found `on Github <https://github.com/odk-x/sync-endpoint-default-setup>`_, and below are some more detailed config for each type of database.
+  3. Modify :file:`jdbc.properties`(under the directory :file:`config/sync-endpoint`) to match your database. Supported database systems are :program:`PostgreSQL`, :program:`MySQL` and :program:`Microsoft SQL Server`. You can find the minimum tested versions of MySQL, PostgreSQL, and MSSQL that are compatible with Sync-Endpoint `here <https://github.com/odk-x/sync-endpoint/blob/master/docs/maven-full.md>`_. Sample config for PostgreSQL can be found `on Github <https://github.com/odk-x/sync-endpoint-default-setup>`_, and below are some more detailed config for each type of database.
   
 	- :code:`jdbc.driverClassName=`
 	


### PR DESCRIPTION

closes odk-x/tool-suite-X#104

#### What is included in this PR?
Added a link to a README file to find the minimum compatible versions of MySQL, PosgreSQL, and MSSQL so users know which databases to use when setting up the Sync-Endpoint locally.

