### PR TITLE
fixed the Broken link in ODK-X Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ We are open to new issues and pull requests.
 
 You can also...
 
- - [Discuss the documentation from a user perspective in our forum](https://forum.odk-x.org/c/development/documentation).
+ - [Discuss the documentation from a user perspective in our forum](https://forum.odk-x.org/).
  - [File an issue](https://github.com/odk-x/tool-suite-X/issues) for any needed improvements.
  - [Watch](https://github.com/odk-x/docs/subscription) and star this repo, to keep up with what we're doing.
 


### PR DESCRIPTION
fixed the Broken link in ODK-X Docs, The README.md file to be precise

The link text on line 250 says "Discuss the documentation from a user perspective in our forum" So I figured that the link should direct users to the ODK-X forum [page ](https://forum.odk-x.org/)instead of [https://forum.odk-x.org/c/development/documentation](url) which leads to a page not found.


