### PR TITLE
Fix Creating framework.xlsx url

### DIFF
--- a/odkx-src/build-app.rst
+++ b/odkx-src/build-app.rst
@@ -313,7 +313,7 @@ The :file:`framework.xlsx` file is central to the structure of the Application D
         -
         -
       * -
-        - | ''?' + odkSurvey.getHashString('census')
+        - | ''?' + odkSurvey.getHashString('Census')
         -
         -
         - external_link


### PR DESCRIPTION
When trying to generate a form using the example provided in the documentation, the url gives an error in `formDef.json`   unless I change census to Census

cc @elmps2018 @wbrunette @Redeem-Grimm-Satoshi