### PR TITLE
Fixes related to branch renaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,5 +105,4 @@ workflows:
           filters:
             branches:
               only: 
-                - main
-                - master                
+                - main             

--- a/src/conf.py
+++ b/src/conf.py
@@ -408,6 +408,6 @@ html_context = {'download_pdf' : download_pdf,
                 'display_github' : True,
                 'github_user' : "odk-x", # Username
                 'github_repo' : "docs", # Repo name
-                'github_version' : "master", # Version
+                'github_version' : "main", # Version
                 'conf_py_path' : "/odkx-src/" # Path in the checkout to the docs root
             }


### PR DESCRIPTION
This PR updates the read the docs template to use correct "Edit on GitHub" url...