### PR TITLE
Fixing docker issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.16-buster
+FROM python:3.12.1
 
 WORKDIR /mnt
 
@@ -13,6 +13,6 @@ RUN apt-get update -y && \
 	python -m pip install --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT ["make"]
+ENTRYPOINT ["make", "dockerserve"]
 
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ help:
 
 .PHONY: help Makefile
 
+dockerserve:
+	sphinx-autobuild --host 0.0.0.0 --port 8080 -b dirhtml "$(SOURCE_DIR)" "$(BUILD_DIR)/html"
+
 serve:
 	sphinx-autobuild -b dirhtml "$(SOURCE_DIR)" "$(BUILD_DIR)/html"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ODK-X Docs
 
-![Platform](https://img.shields.io/badge/platform-Sphinx-blue.svg) [![License](https://img.shields.io/badge/license-CC%20BY%204.0-blue.svg)](https://creativecommons.org/licenses/by/4.0/) [![Build status](https://circleci.com/gh/odk-x/docs.svg?style=svg)](https://circleci.com/gh/odk-x/docs/)  [![Netlify Status](https://api.netlify.com/api/v1/badges/d3788b3e-1abc-431d-a9a3-e5c71b20e053/deploy-status)](https://app.netlify.com/sites/blissful-bohr-7f32fb/deploys)
+![Platform](https://img.shields.io/badge/platform-Sphinx-blue.svg) [![License](https://img.shields.io/badge/license-CC%20BY%204.0-blue.svg)](https://creativecommons.org/licenses/by/4.0/) [![Build status](https://circleci.com/gh/odk-x/docs.svg?style=svg)](https://circleci.com/gh/odk-x/docs/)
 
 This repo is the source for ODK-X documentation.
 
@@ -93,14 +93,17 @@ Take note of the full-stop `.` at the end of the build command. The `.` specifie
 ### Building and serving the docs locally
 
 Build and serve the docs locally with:
- * Windows: `.\run-task.bat serve`
- * Linux/macOS: `./run-task.sh serve`
+ * Windows: `.\run-task.ps1`
+ * Linux/macOS: `./run-task.sh`
 
 Once your terminal shows a "Serving on http://0.0.0.0:8080" message, you can then view the docs in your browser at http://localhost:8080.
 
-Changes you make in the source files will automatically be built and shown in your browser.
+Changes you make in the source files (located in the `./src` folder) will automatically be re-built and shown in your browser.
 
-Press `Ctrl-C` on your keyboard to stop the build server. It could take a while to effectively stop, and you can always close the terminal window.
+* Linux/macOs: Press `Ctrl-C` on your keyboard to stop the build server. It could take a while to effectively stop, and you can always close the terminal window.
+
+* Windows: To stop the build server open up a new terminal and type the command ```docker stop odkx-docs```
+
 
 If you get a `The name "odkx-docs" is already in use by container` error message, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,17 @@ Once your terminal shows a "Serving on http://0.0.0.0:8080" message, you can the
 
 Changes you make in the source files (located in the `./src` folder) will automatically be re-built and shown in your browser.
 
-* Linux/macOs: Press `Ctrl-C` on your keyboard to stop the build server. It could take a while to effectively stop, and you can always close the terminal window.
+* Windows: The docker container with the docs website will occupy the terminal window and output log messages when changes are detected and rebuilds are made. Open a new terminal window/tab to be able to stop the container using the command below.
+* Linux/macOs: Open a new terminal to interact with the container or press `Ctrl-Z` on your keyboard to suspend the job. The job will still be running in the background and changes will automatically be rebuilt and served.
 
-* Windows: To stop the build server open up a new terminal and type the command ```docker stop odkx-docs```
+
+To stop the container, type the following command
+
+```
+docker stop odkx-docs
+```
+ 
+
 
 
 If you get a `The name "odkx-docs" is already in use by container` error message, run the following command:

--- a/run-task.bat
+++ b/run-task.bat
@@ -1,1 +1,0 @@
-docker run --rm -v "%~dp0:/mnt" -p 8080:8080 --name odkx-docs odkx-docs %1

--- a/run-task.ps1
+++ b/run-task.ps1
@@ -1,1 +1,1 @@
-docker run --rm -v "${PWD}:/mnt" -p 8000:8000 --name odkx-docs odkx-docs $args
+docker run --rm -v "${PWD}:/mnt" -p 8000:8000 --name odkx-docs odkx-docs

--- a/run-task.ps1
+++ b/run-task.ps1
@@ -1,0 +1,1 @@
+docker run --rm -v "${PWD}:/mnt" -p 8000:8000 --name odkx-docs odkx-docs $args

--- a/run-task.sh
+++ b/run-task.sh
@@ -2,4 +2,4 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-docker run --rm -v "${DIR}":/mnt -p 8080:8080 --name odkx-docs odkx-docs "$1"
+docker run --rm -v "${DIR}":/mnt -p 8080:8080 --name odkx-docs odkx-docs


### PR DESCRIPTION
# This PR aims to fix errors introduced by the switch to new Sphinx build system, mainly errors preventing serving the website through docker;
- Added "dockerserve" task to Makefile, overriding sphinx-autobuild to bind to 0.0.0.0:8080 instead of default 127.0.0.1:8000

## Other updates:
- Updated the Dockerfile to build on latest python image (3.12.1) and changed entrypoint to include the "dockerserve" command to simplify usage in run-task scripts
- Updated run-task scripts to not use command line args
- Migrated from legacy cmd `.bat` script to `.ps1` powershell to align with README instructions
- Updated README.md to reflect changes

## Tested on:
- Windows
- MacOS

## Issues/Problems:
- CTRL+C (and CTRL+P CTRL+C) does not detach from the docker container (due to the ENTRYPOINT being the "make" command, I believe). Tried to fix it, but couldn't find a consistently working fix across mac and windows - so I updated the README instead to reflect that the `docker stop` command must be issued from a separate terminal.