### PR TITLE
Fixed port number in docker command 

### DIFF
--- a/run-task.ps1
+++ b/run-task.ps1
@@ -1,1 +1,1 @@
-docker run --rm -v "${PWD}:/mnt" -p 8000:8000 --name odkx-docs odkx-docs
+docker run --rm -v "${PWD}:/mnt" -p 8080:8080 --name odkx-docs odkx-docs


### PR DESCRIPTION
The port number in the ps1 file is incorrect - it should be 8080 to match what the container exposes.
(it is correct in the equivalent .sh file used on macOS)