### PR TITLE
Fix issue 471

### DIFF
--- a/src/notify-install.rst
+++ b/src/notify-install.rst
@@ -53,7 +53,7 @@ Setting up ODK-X Notify
 
     .. image:: /img/notify-setup/notify-setup.*
 
-  4. To use the Skunkworks-Parrot App, the user needs to create a firebase project and add that project's information in the configure window. The step-by-step instructions can be found in this `guide <https://drive.google.com/file/d/1OBs5mITcIMREp_q7qKwEwO4XRQjzNnWj/view>`_.
+  4. To use the Skunkworks-Parrot App, the user needs to create a firebase project and add that project's information in the configure window. The step-by-step instructions can be found in this `guide < https://drive.google.com/file/d/1OBs5mITcIMREp_q7qKwEwO4XRQjzNnWj/view>`_.
 
   5. After adding all the required information in configure window, Click :menuselection:`Save`.
 
@@ -67,7 +67,7 @@ Setting up ODK-X Notify
 
 1. Download all the folders from this `link <https://drive.google.com/drive/folders/1_WOhFrUDW2yLjeOaI5gW2AKiq-akGB78?usp=sharing>`_ and move them to :file:`sdcard/opendatakit/default/config/tables/` directory in your android device.
 
-2. Place “google-services.json” file obtained from step 8 of `firebase setup <https://drive.google.com/file/d/1OBs5mITcIMREp_q7qKwEwO4XRQjzNnWj/view>`_ under the :file:`sdcard/opendatakit/default/config/assets/` directory.
+2. Place “google-services.json” file obtained from step 8 of `firebase setup  <https://drive.google.com/file/d/1OBs5mITcIMREp_q7qKwEwO4XRQjzNnWj/view>`_ under the :file:`sdcard/opendatakit/default/config/assets/` directory.
 
 3. Open the ODK-X Tables app. Tables app will automatically generate all the required files for server setup. After you see the message “Initialization completed successfully” you can close the ODK-X Tables app.
 

--- a/src/notify-install.rst
+++ b/src/notify-install.rst
@@ -53,7 +53,7 @@ Setting up ODK-X Notify
 
     .. image:: /img/notify-setup/notify-setup.*
 
-  4. To use the Skunkworks-Parrot App, the user needs to create a firebase project and add that project's information in the configure window. The step-by-step instructions can be found in this `guide < https://drive.google.com/file/d/1OBs5mITcIMREp_q7qKwEwO4XRQjzNnWj/view>`_.
+  4. To use the Skunkworks-Parrot App, the user needs to create a firebase project and add that project's information in the configure window. The step-by-step instructions can be found in this `guide <https://drive.google.com/drive/folders/1kAnf1aUDwK0GAPJw4xGoEL5CVBJGB6Si?usp=sharing>`_.
 
   5. After adding all the required information in configure window, Click :menuselection:`Save`.
 
@@ -67,7 +67,7 @@ Setting up ODK-X Notify
 
 1. Download all the folders from this `link <https://drive.google.com/drive/folders/1_WOhFrUDW2yLjeOaI5gW2AKiq-akGB78?usp=sharing>`_ and move them to :file:`sdcard/opendatakit/default/config/tables/` directory in your android device.
 
-2. Place “google-services.json” file obtained from step 8 of `firebase setup  <https://drive.google.com/file/d/1OBs5mITcIMREp_q7qKwEwO4XRQjzNnWj/view>`_ under the :file:`sdcard/opendatakit/default/config/assets/` directory.
+2. Place “google-services.json” file obtained from step 8 of `firebase setup <https://drive.google.com/drive/folders/1kAnf1aUDwK0GAPJw4xGoEL5CVBJGB6Si?usp=sharing>`_ under the :file:`sdcard/opendatakit/default/config/assets/` directory.
 
 3. Open the ODK-X Tables app. Tables app will automatically generate all the required files for server setup. After you see the message “Initialization completed successfully” you can close the ODK-X Tables app.
 


### PR DESCRIPTION
Pull Request releted to [issue#471](https://github.com/odk-x/tool-suite-X/issues/471)

The broken hyperlink issue has been resolved not only in the "guide" hyperlink mentioned previously but also in another location within the documentation. Specifically, in the passage discussing the Firebase setup, there was also a broken link. The problematic link was within the sentence: "Place the 'google-services.json' file obtained from step 8 of the Firebase setup under the 'sdcard/opendatakit/default/config/assets/' directory