### PR TITLE
fixing the typo error in contributing-tips.rst

### DIFF
--- a/src/contributing-tips.rst
+++ b/src/contributing-tips.rst
@@ -10,9 +10,9 @@ Tips for Making Good Contributions
 Smallest meaningful PR
 ------------------------
 
-A PR should normally address one issue. This makes it easier to review, easier to deploy, and easier to roll back in case of a problem. Additionally, the smaller the PR, the less likely it is to create a merge issue.
+A PR should normally address one issue. This makes it easier to review, deploy, and rollback in case of a problem. Additionally, the smaller the PR, the less likely it is to create a merge conflict.
 
-The exception is when several issues are closely related or can reasonably be worked on together.  In this case, it should be clear by looking at the conversation on the Github issues that the items are related and will be worked on together. Your PR message should also make it clear which issues are being worked on, and whether the PR closes the issues or not. Mention the PR by number:
+The exception is when several issues are closely related or can reasonably be worked on together. In this case, it should be clear from the conversation on the GitHub issues that the items are related and will be worked on together. Your PR message should also make it clear which issues are being addressed and whether the PR closes the issues or not. Mention the PR by number:
 
   addresses #123
 
@@ -30,7 +30,7 @@ Good PR titles:
 
 - adds a video directive
 - makes navigation buttons responsive
-- swaps placement of nav buttons and file an issue note
+- swaps placement of navigation buttons and file an issue note
 
 Bad PR titles:
 
@@ -45,13 +45,13 @@ Small, atomic commits
 
 When working locally, commit often. Don't wait until you have 100 lines of changes across multiple files.
 
-- If you need to copy or move a large section or file, commit that change before also editing it.
-- If you have to create a new template file based on an existing template file, copy the file in one commit and then work on the changes. This makes it easier to know what you actually did.
-- If writing a new doc, commits after each new section are a good idea.
+- If you need to copy or move a large section or file, commit that change before editing it further.
+- If you have to create a new template file based on an existing template file, copy the file in one commit and then work on the changes. This makes it easier to track your changes.
+- When writing a new document, committing after each new section is a good idea.
 
 Commit messages should answer the question, "What does this commit do?"
 
-Small, well-named commits will help you keep track of your own work and make rollbacks and other changes easier to deal with.
+Small, well-named commits will help you keep track of your own work and make rollbacks and other changes easier to manage.
 
 
 .. _discuss-issues:
@@ -59,15 +59,15 @@ Small, well-named commits will help you keep track of your own work and make rol
 Discuss issues before working
 --------------------------------
 
-Take the time to clarify the needs and scope of an issue before committing to work on it. Especially for coding tasks, make sure you state your understanding and your plan before working.
+Take the time to clarify the needs and scope of an issue before committing to work on it. Especially for coding tasks, make sure you state your understanding and your plan before starting.
 
 If you have a question, ask. Don't guess.
 
 .. note::
 
-  Many new contributors don't ask questions because they are worried about appearing under informed. Please set this worry aside.
+  Many new contributors don't ask questions because they are worried about appearing uninformed. Please set this worry aside.
 
-  **You will never be judged harshly for asking clarifying questions or for seeking more information.**
+  **You will never be judged harshly for asking clarifying questions or seeking more information.**
 
 .. _claim-issues:
 
@@ -86,7 +86,7 @@ Don't claim more than one or two open issues at a time.
 Share work in progress
 -------------------------
 
-It can be helpful to share your in-progress work. To mark a PR as a work in progress, append **WIP:** to the beginning of the PR title. We will not merge **WIP** PRs, and we won't do a review on them unless you ask.
+It can be helpful to share your work in progress. To mark a PR as a work in progress, append **WIP:** to the beginning of the PR title. We will not merge **WIP** PRs, and we won't review them unless you ask.
 
 If you want a review, comment, opinion, or help on a **WIP** PR, please tag the relevant person in the PR comments.
 
@@ -106,7 +106,7 @@ If you get stuck while working
 
   - If we can see what progress you have made, it is easier to offer help.
   - Even if you don't complete the task, perhaps someone else can pull in your in-progress work and build on it.
-  - Sometimes your in-progress work is an improvement over not having it, and so we'll merge in something even if it isn't complete.
+  - Sometimes your in-progress work is an improvement over not having it, and so we'll merge it even if it isn't complete.
 
 - If you really cannot move forward, it is okay to abandon an issue.
 
@@ -115,52 +115,52 @@ If you get stuck while working
 It is okay to abandon an issue
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sometimes you simply cannot complete work you have said you were going to complete. This could happen because you don't have all the required skills or knowledge to complete the work, or because the issue cannot actually be completed as scoped, or because you don't have the time.
+Sometimes you simply cannot complete work you have committed to completing. This could happen because you lack the required skills or knowledge, or because the issue cannot be completed as scoped, or because you don't have the time.
 
 Please let the community know in the issue discussion. You can do that by leaving a comment asking to be unassigned from the issue.
 
 This way, everyone knows that someone else can take up the project (or that we need to rethink it).
 
-If you did significant work on a project before abandoning it, consider filing a **WIP** (work in progress) PR, so that others can see what you did and potentially build off of it. (Be sure to mention the issue, so the work is easy to find later.)
+If you have made significant progress on a project before abandoning it, consider filing a **WIP** (work in progress) PR so that others can see what you have done and potentially build off of it. (Be sure to mention the issue so that the work is easy to find later.)
 
 .. _issue-takes-long-time:
 
 If an issue takes a long time to complete
 -------------------------------------------
 
-For our purposes, a "long time" is a week or more, from when you first announce your intention to work on something until submitting a merge-ready PR.
+For our purposes, a "long time" is a week or more from when you first announced your intention to work on something until submitting a merge-ready PR.
 
 An issue might take a long time because:
 
-- it is complex and requires lots of hours
+- it is complex and requires many hours
 - you only have a short period of time each day to work on it
-- you are new to the project and are having to learn as you go
+- you are new to the project and are learning as you go
 
-The thing that matters is: **Are you actively working on the issue, and making progress, at least a little bit?**
+What matters is: **Are you actively working on the issue and making progress, at least a little bit?**
 
-If you are actively working on it, we do not want someone else to jump on and try to work on it at the same time. So please keep the community informed of your work by filing a **WIP** (work in progress) PR and committing to it as you work.
+If you are actively working on it, we do not want someone else to jump in and try to work on it at the same time. So please keep the community informed of your work by filing a **WIP** (work in progress) PR and committing to it as you work.
 
 .. _issues-only:
 
 Issues only
 ----------------
 
-All PRs must be directly connected to open issues. PRs should not represent suggestions, good ideas, or independent initiative.
+All PRs must be directly connected to open issues. PRs should not represent suggestions, good ideas, or independent initiatives.
 
 If you have a good idea, file an issue. 
 
-Once you have filed an issue, wait for comment and approval before diving into the work. We do not want surprise PRs.
+Once you have filed an issue, wait for comments and approval before diving into the work. We do not want surprise PRs.
 
 .. _use-odk:
 
 Actually install and use ODK-X or other tools
 ----------------------------------------------------------
 
-You cannot write effectively about tools you have not used. If you're going to write or edit documentation about any of the apps in the ODK ecosystem, you need to spend some time actually using it.
+You cannot write effectively about tools you have not used. If you're going to write or edit documentation about any of the apps in the ODK ecosystem, you need to spend some time actually using them.
 
 Before diving into writing documentation, try out the `core tools <https://odk-x.org/software>`_ and become familiar with them.
 
-This is also true of writing about Sphinx or any of our documentation build tools. Reading existing documentation is not enough to write about something.
+This is also true when writing about Sphinx or any of our documentation build tools. Reading existing documentation is not enough to write about something.
 
 .. _do-the-thing:
 
@@ -185,13 +185,13 @@ You are not an impostor
 
 `Impostor syndrome <https://en.wikipedia.org/wiki/Impostor_syndrome>`_ is the feeling that you are not good enough or accomplished enough to do the work you are doing.
 
-We all feel this way sometimes, and that's okay. But it is important to realize that **you are not an impostor.**
+We all feel this way sometimes, and that's okay. But it is important to realize that **you are not an impostor**.
 
 You can contribute to this community, no matter your background or skills.
 
 - If there is something you don't know how to do, you can ask.
 
-  - If it is issue related, ask on the issue.
+  - If it is issue-related, ask on the issue.
 
 - If you want to try something even though you aren't sure you can do it, go ahead and try.
 


### PR DESCRIPTION
This PR is realted to the [issue](https://github.com/odk-x/tool-suite-X/issues/207)
Corrected punctuation, grammar, and capitalization errors in contributing-tips.rst file .
