### PR TITLE
Updated build-app.rst

### DIFF
--- a/src/build-app.rst
+++ b/src/build-app.rst
@@ -198,7 +198,7 @@ The :file:`framework.xlsx` file is central to the structure of the Application D
  
   3. Rename the :file:`framework.clean` folder to :file:`framework`
 
-  4. The *initial* worksheet of :file:`framework.xlsx` should have a header: :th:`clause` and value :tc:`do section survey`.
+  4. The *initial* worksheet of :file:`framework.xlsx` should have a header: :th:`clause` and value: :tc:`do section survey`.
 
     .. list-table:: *initial* worksheet
       :header-rows: 1
@@ -350,7 +350,7 @@ Assuming you have created a :file:`testForm.xlsx`, the appropriate directory str
 The following changes will also need to be made to the :file:`framework.xlsx` **choices worksheet**
 
 .. csv-table:: Example Framework Choices Worksheet
-  :header: "choice_list_name", "data_value", "display.text"
+  :header: "choice_list_name", "data_value", "display.title.text"
 
   "test_forms", "testForm", "testForm"
 


### PR DESCRIPTION
This PR addresses [#485](https://github.com/odk-x/tool-suite-X/issues/485)


#### What is included in this PR?
Updated the documentation to address some consistency issues in the **build-app.rst** file.


The **choices worksheet** in **framwork.xlsx** should contain a header called `display.title.text:`

<img width="800" alt="Screenshot 2024-10-25 at 17 39 59" src="https://github.com/user-attachments/assets/974c9003-bbd9-4008-8cbe-0bb93cabc142">

But it was referenced as `display.text` later in the document:
<img width="796" alt="Screenshot 2024-10-25 at 17 54 44" src="https://github.com/user-attachments/assets/c4e3cde1-d590-40ef-a964-1deb7d0514a6">

So i updated it to the correct header name:
<img width="802" alt="Screenshot 2024-10-25 at 17 54 27" src="https://github.com/user-attachments/assets/99d136bd-7007-49e5-b0f6-ff48907ed53f">

