### PR TITLE
Update sync-endpoint-manual-setup documentation after succesfully setting up an endpoint

### DIFF
--- a/src/sync-endpoint-manual-setup.rst
+++ b/src/sync-endpoint-manual-setup.rst
@@ -65,12 +65,15 @@ Setup instructions:
   .. code-block:: console
 
     $ cd sync-endpoint
+  .. note::
+
+     You may also use the autosetup found in the root directory of the repository :guilabel:`init-odkx-sync-endpoint.py` to setup automatically
 	
   5. Build sync endpoint by running the following: (NOTE: you will need Apache Maven installed >= 3.3.3)
   
   .. code-block:: console
 
-    $ mvn clean install
+    $ mvn clean install -DskipTests
 	
   6. Navigate back to the parent "sync-endpoint-default-setup" directory. 
   


### PR DESCRIPTION
Very minor changes that would have helped me save some time for my setup 
Added that the autosetup python script may be used and a flag that is required for maven to not fail during install if doing it manually


#### What is included in this PR?
Added two lines to the documentation page of sync-endpoint-manual-setup